### PR TITLE
[task/35506] - add callback to handle event data from library items

### DIFF
--- a/python/transformations/empty-template/main.py
+++ b/python/transformations/empty-template/main.py
@@ -19,10 +19,17 @@ def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer, df: pd.Dat
     stream_producer.timeseries.buffer.publish(df)
 
 
+# Handle event data from library items that emit event data
+def on_event_data_received_handler(stream_consumer: qx.StreamConsumer, data: qx.EventData):
+    print(data)
+    # handle your event data here
+
+
 def on_stream_received_handler(stream_consumer: qx.StreamConsumer):
     # subscribe to new DataFrames being received
     # if you aren't familiar with DataFrames there are other callbacks available
     # refer to the docs here: https://docs.quix.io/sdk/subscribe.html
+    stream_consumer.events.on_data_received = on_event_data_received_handler # register the event data callback
     stream_consumer.timeseries.on_dataframe_received = on_dataframe_received_handler
 
 


### PR DESCRIPTION
## Description

By default the empty/template Python transform does not handle event data. This is an issue because if you connect it to a standard library item that emits event data, this template won't have a facility to display or handle that event data.

[Ticket](https://app.shortcut.com/quix/story/35506/add-event-data-callback-to-python-empty-transform)

## Review

My first code modification to a standard library item, so careful scrutiny of the change is required.