### PR TITLE
Improve performance of linechart drawing in multiple tabs

### DIFF
--- a/python/destinations/streamlit/streamlit_file.py
+++ b/python/destinations/streamlit/streamlit_file.py
@@ -5,7 +5,7 @@ import streamlit as st
 from app.conf import (
     STREAMLIT_DATAFRAME_POLL_PERIOD,
 )
-from app.streamlit_utils import get_stream_df, draw_line_chart_concurrently
+from app.streamlit_utils import get_stream_df, draw_line_chart_failsafe
 
 # Basic configuration of the Streamlit dashboard
 st.set_page_config(
@@ -77,7 +77,7 @@ while True:
 
     with placeholder_col1.container():
         # Plot line chart in the first column
-        draw_line_chart_concurrently(
+        draw_line_chart_failsafe(
             real_time_df_copy,
             # Use "datetime" column for X axis
             x="datetime",
@@ -88,7 +88,7 @@ while True:
 
     # Plot line chart in the second column
     with placeholder_col2.container():
-        draw_line_chart_concurrently(
+        draw_line_chart_failsafe(
             real_time_df_copy,
             x="datetime",
             # Use a column from the second select widget for Y axis


### PR DESCRIPTION
**Problem:**
The function `st.line_chart` sometimes fails with `Runtime Error: dictionary changed size during iteration`. 
It happens randomly, and the dashboard stops updating itself.
To prevent it, the shared lock was used. 
But it increases the latency of updates when there are more opened tabs.

**Solution:**
To fail silently with a log message when this exact RuntimeError error happens. 
Assume that the chart will be re-rendered in ~0.5-1sec.