### PR TITLE
Adding first draft of SDF versions of InfluxDB v2/3 Input/Output Connectors

### DIFF
--- a/python/destinations/InfluxDB/library.json
+++ b/python/destinations/InfluxDB/library.json
@@ -70,6 +70,14 @@
       "Description": "The InfluxDB measurement to write data to. If not specified, the name of the input topic will be used",
       "DefaultValue": "",
       "Required": false
+        },
+    {
+      "Name": "INFLUXDB_FIELD_KEYS",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "The fields to include when writing the measurement data",
+      "DefaultValue": "['field1','field2']",
+      "Required": true
     }
   ]
 }

--- a/python/destinations/InfluxDB/main.py
+++ b/python/destinations/InfluxDB/main.py
@@ -1,43 +1,60 @@
-from quixstreams import Application
-from quixstreams.models.serializers.quix import JSONDeserializer
+# import Utility modules
 import os
-import influxdb_client_3 as InfluxDBClient3
 import ast
 import datetime
-import pandas as pd
+import logging
+
+# import vendor-specific modules
+from quixstreams import Application
+from quixstreams.models.serializers.quix import JSONDeserializer
+from influxdb_client_3 import InfluxDBClient3
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = Application.Quix(consumer_group="influx-destination",
                        auto_offset_reset="earliest")
 
 input_topic = app.topic(os.environ["input"], value_deserializer=JSONDeserializer())
 
-# Read the environment variable and convert it to a list
-tag_columns = ast.literal_eval(os.environ.get('INFLUXDB_TAG_COLUMNS', "[]"))
+# Read the environment variable and convert it to a dictionary
+tag_dict = ast.literal_eval(os.environ.get('INFLUXDB_TAG_COLUMNS', "{}"))
 
-# Read the environment variable for measurement name and convert it to a list
+# Read the environment variable for measurement name
 measurement_name = os.environ.get('INFLUXDB_MEASUREMENT_NAME', os.environ["input"])
+
+# Read the environment variable for the field(s) to get.
+# For multiple fields, use a list "['field1','field2']"
+field_keys = os.environ.get("field_keys", "['field1']")
                                            
-client = InfluxDBClient3.InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
+influx3_client = InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
                          host=os.environ["INFLUXDB_HOST"],
                          org=os.environ["INFLUXDB_ORG"],
                          database=os.environ["INFLUXDB_DATABASE"])
 
-def send_data_to_influx(row):
+def send_data_to_influx(message):
+    logger.info(f"Processing message: {message}")
     try:
-        # Convert the dictionary to a DataFrame
-        row_df = pd.DataFrame([row])
+        quixtime = message['time']
+        # Get the name(s) and value(s) of the selected field(s)
+        # Using just a single field in this example for simplicity
+        field1_name = field_keys[0]
+        field1_value = message[field_keys[0]]
 
-        # Reformat the dataframe to match the InfluxDB format
-        row_df = row_df.rename(columns={'timestamp': 'time'})
-        row_df = row_df.set_index('time')
+        logger.info(f"Using field keys: {', '.join(field_keys)}")
 
-        client._write_api.write(
-            bucket=os.environ["INFLUXDB_DATABASE"], 
-            record=row_df, 
-            data_frame_measurement_name=measurement_name, 
-            data_frame_tag_columns=tag_columns)
+        # Using point dictionary structure
+        # See: https://docs.influxdata.com/influxdb/cloud-dedicated/reference/client-libraries/v3/python/#write-data-using-a-dict
+        points = {
+            "measurement": measurement_name,
+            "tags": tag_dict,
+            "fields": {field1_name: field1_value},
+            "time": quixtime
+        }
 
-        print(f"{str(datetime.datetime.utcnow())}: Persisted {row_df.shape[0]} rows.")
+        influx3_client.write(record=points, write_precision="ms")
+        
+        print(f"{str(datetime.datetime.utcnow())}: Persisted measurement to influx.")
     except Exception as e:
         print(f"{str(datetime.datetime.utcnow())}: Write failed")
         print(e)

--- a/python/destinations/InfluxDB/main.py
+++ b/python/destinations/InfluxDB/main.py
@@ -1,21 +1,20 @@
-import quixstreams as qx
+from quixstreams import Application
+from quixstreams.models.serializers.quix import JSONDeserializer
 import os
-import pandas as pd
 import influxdb_client_3 as InfluxDBClient3
 import ast
 import datetime
+import pandas as pd
 
+app = Application.Quix(consumer_group="influx-destination",
+                       auto_offset_reset="earliest")
 
-client = qx.QuixStreamingClient()
-
-# get the topic consumer for a specific consumer group
-topic_consumer = client.get_topic_consumer(topic_id_or_name = os.environ["input"],
-                                           consumer_group = "empty-destination")
+input_topic = app.topic(os.environ["input"], value_deserializer=JSONDeserializer())
 
 # Read the environment variable and convert it to a list
 tag_columns = ast.literal_eval(os.environ.get('INFLUXDB_TAG_COLUMNS', "[]"))
 
-# Read the enviroment variable for measurement name and convert it to a list
+# Read the environment variable for measurement name and convert it to a list
 measurement_name = os.environ.get('INFLUXDB_MEASUREMENT_NAME', os.environ["input"])
                                            
 client = InfluxDBClient3.InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
@@ -23,36 +22,29 @@ client = InfluxDBClient3.InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
                          org=os.environ["INFLUXDB_ORG"],
                          database=os.environ["INFLUXDB_DATABASE"])
 
-
-def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer, df: pd.DataFrame):
+def send_data_to_influx(row):
     try:
+        # Convert the dictionary to a DataFrame
+        row_df = pd.DataFrame([row])
+
         # Reformat the dataframe to match the InfluxDB format
-        df = df.rename(columns={'timestamp': 'time'})
-        df = df.set_index('time')
-        df["stream_id"] = stream_consumer.stream_id
+        row_df = row_df.rename(columns={'timestamp': 'time'})
+        row_df = row_df.set_index('time')
 
-        client.write(df, data_frame_measurement_name=measurement_name, data_frame_tag_columns=tag_columns) 
+        client._write_api.write(
+            bucket=os.environ["INFLUXDB_DATABASE"], 
+            record=row_df, 
+            data_frame_measurement_name='conversationstest', 
+            data_frame_tag_columns=tag_columns)
 
-        print(f"{str(datetime.datetime.utcnow())}: Persisted {df.shape[0]} rows.")
+        print(f"{str(datetime.datetime.utcnow())}: Persisted {row_df.shape[0]} rows.")
     except Exception as e:
-        print("{str(datetime.datetime.utcnow())}: Write failed")
+        print(f"{str(datetime.datetime.utcnow())}: Write failed")
         print(e)
 
+sdf = app.dataframe(input_topic)
+sdf = sdf.update(send_data_to_influx)
 
-def on_stream_received_handler(stream_consumer: qx.StreamConsumer):
-    
-    # Buffer to batch rows every 250ms to reduce CPU overhead.
-    buffer = stream_consumer.timeseries.create_buffer()
-    buffer.time_span_in_milliseconds = 250
-    buffer.buffer_timeout = 250
-
-    buffer.on_dataframe_released = on_dataframe_received_handler
-
-
-# subscribe to new streams being received
-topic_consumer.on_stream_received = on_stream_received_handler
-
-print("Listening to streams. Press CTRL-C to exit.")
-
-# Handle termination signals and provide a graceful exit
-qx.App.run()
+if __name__ == "__main__":
+    print("Starting application")
+    app.run(sdf)

--- a/python/destinations/InfluxDB/main.py
+++ b/python/destinations/InfluxDB/main.py
@@ -25,7 +25,7 @@ measurement_name = os.environ.get('INFLUXDB_MEASUREMENT_NAME', os.environ["input
 
 # Read the environment variable for the field(s) to get.
 # For multiple fields, use a list "['field1','field2']"
-field_keys = os.environ.get("field_keys", "['field1']")
+field_keys = os.environ.get("INFLUXDB_FIELD_KEYS", "['field1','field2']")
                                            
 influx3_client = InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
                          host=os.environ["INFLUXDB_HOST"],
@@ -37,7 +37,7 @@ def send_data_to_influx(message):
     try:
         quixtime = message['time']
         # Get the name(s) and value(s) of the selected field(s)
-        # Using just a single field in this example for simplicity
+        # Using a single field in this example for simplicity
         field1_name = field_keys[0]
         field1_value = message[field_keys[0]]
 

--- a/python/destinations/InfluxDB/main.py
+++ b/python/destinations/InfluxDB/main.py
@@ -34,7 +34,7 @@ def send_data_to_influx(row):
         client._write_api.write(
             bucket=os.environ["INFLUXDB_DATABASE"], 
             record=row_df, 
-            data_frame_measurement_name='conversationstest', 
+            data_frame_measurement_name=measurement_name, 
             data_frame_tag_columns=tag_columns)
 
         print(f"{str(datetime.datetime.utcnow())}: Persisted {row_df.shape[0]} rows.")

--- a/python/destinations/InfluxDB/requirements.txt
+++ b/python/destinations/InfluxDB/requirements.txt
@@ -1,2 +1,3 @@
-quixstreams==0.5.7
-influxdb3-python==0.3.0
+quixstreams==2.2.0a0
+influxdb3-python==0.3.6
+pandas

--- a/python/destinations/InfluxDB/requirements.txt
+++ b/python/destinations/InfluxDB/requirements.txt
@@ -1,4 +1,2 @@
-quixstreams==2.2.0a0
+quixstreams>=2.3.1
 influxdb3-python==0.3.6
-pandas
-polars

--- a/python/destinations/InfluxDB/requirements.txt
+++ b/python/destinations/InfluxDB/requirements.txt
@@ -1,3 +1,4 @@
 quixstreams==2.2.0a0
 influxdb3-python==0.3.6
 pandas
+polars

--- a/python/sources/InfluxDB-2.0/library.json
+++ b/python/sources/InfluxDB-2.0/library.json
@@ -20,14 +20,14 @@
       "Type" : "EnvironmentVariable",
       "InputType" : "OutputTopic",
       "Description" : "This is the Quix topic that will receive the stream",
-      "DefaultValue" : "influxdb",
+      "DefaultValue" : "influxdbv2-data",
       "Required": true
   },
     {
       "Name": "task_interval",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
-      "Description": "Interval to run query. Must be within the InfluxDB notation; 1s, 1m, 1h, 1d, 1w, 1mo, 1y",
+      "Description": "Interval to run query. Must be within the InfluxDB notation; 1s, 1m, 1h, 1d, 1w, 1y",
       "DefaultValue": "5m",
       "Required": true
     },

--- a/python/sources/InfluxDB-2.0/main.py
+++ b/python/sources/InfluxDB-2.0/main.py
@@ -87,16 +87,16 @@ def get_data():
             if not table.empty:
                 json_result = table.to_json(orient='records', date_format='iso')
                 yield json_result
-                print("query success")
+                logger.info("query success")
             else:
-                print("No new data to publish.")
+                logger.info("No new data to publish.")
 
             # Wait for the next interval
             sleep(interval_seconds)
 
         except Exception as e:
-            print("query failed", flush=True)
-            print(f"error: {e}", flush=True)
+            logger.info("query failed", flush=True)
+            logger.info(f"error: {e}", flush=True)
             sleep(1)
 
 def main():
@@ -135,4 +135,4 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        print("Exiting.")
+        logger.info("Exiting.")

--- a/python/sources/InfluxDB-2.0/main.py
+++ b/python/sources/InfluxDB-2.0/main.py
@@ -1,15 +1,21 @@
-# Importing necessary libraries and modules
-from quixstreams import Application
-from quixstreams.models.serializers.quix import JSONSerializer, SerializationContext
+# Import basic utilities
 import os
 import random
-import influxdb_client
+import json
+import logging
 from time import sleep
-from datetime import datetime
-import pandas as pd
 
-# Create an Application
-app = Application.Quix(auto_create_topics=True)
+# import vendor-specfic modules
+from quixstreams import Application
+from quixstreams.models.serializers.quix import JSONSerializer, SerializationContext
+import influxdb_client
+
+# Initialize logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Create a Quix Application
+app = Application.Quix(consumer_group="influxdbv2_sample", auto_create_topics=True)
 
 # Define a serializer for messages, using JSON Serializer for ease
 serializer = JSONSerializer()
@@ -18,83 +24,80 @@ serializer = JSONSerializer()
 topic_name = os.environ["output"]
 topic = app.topic(topic_name)
 
-client = influxdb_client.InfluxDBClient(token=os.environ["INFLUXDB_TOKEN"],
+influxdb2_client = influxdb_client.InfluxDBClient(token=os.environ["INFLUXDB_TOKEN"],
                         org=os.environ["INFLUXDB_ORG"],
                         url=os.environ['INFLUXDB_HOST'])
-query_api = client.query_api()
 
-measurement_name = os.environ.get("INFLUXDB_MEASUREMENT_NAME", os.environ["output"])
+query_api = influxdb2_client.query_api()
+
+measurement = os.environ.get("INFLUXDB_MEASUREMENT_NAME", os.environ["output"])
+interval = os.environ.get("task_interval", "5m")
+bucket = os.environ.get("INFLUXDB_BUCKET", "placeholder-bucket")
 
 # Global variable to control the main loop's execution
 run = True
 
 # Helper function to convert time intervals (like 1h, 2m) into seconds for easier processing.
 # This function is useful for determining the frequency of certain operations.
-def interval_to_seconds(interval):
-    if not interval:
-        raise ValueError("Invalid interval string")
+UNIT_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+    "y": 31536000,
+}
 
-    unit = interval[-1].lower()
+def interval_to_seconds(interval: str) -> int:
     try:
-        value = int(interval[:-1])
-    except ValueError:
-        raise ValueError("Invalid interval format")
+        return int(interval[:-1]) * UNIT_SECONDS[interval[-1]]
+    except ValueError as e:
+        if "invalid literal" in str(e):
+            raise ValueError(
+                "interval format is {int}{unit} i.e. '10h'; "
+                f"valid units: {list(UNIT_SECONDS.keys())}")
+    except KeyError:
+        raise ValueError(
+            f"Unknown interval unit: {interval[-1]}; "
+            f"valid units: {list(UNIT_SECONDS.keys())}")
 
-    if unit == 's':
-        return value
-    elif unit == 'm':
-        return value * 60
-    elif unit == 'h':
-        return value * 3600
-    elif unit == 'd':
-        return value * 3600 * 24
-    elif unit == 'mo':
-        return value * 3600 * 24 * 30
-    elif unit == 'y':
-        return value * 3600 * 24 * 365
-    else:
-        raise ValueError(f"Unknown interval unit: {unit}")
-
-
-interval = os.environ.get("task_interval", "5m")
 interval_seconds = interval_to_seconds(interval)
-bucket = os.environ["INFLUXDB_BUCKET"]
-measurement = os.environ['INFLUXDB_MEASUREMENT_NAME']
 
 # Function to fetch data from InfluxDB and send it to Quix
 # It runs in a continuous loop, periodically fetching data based on the interval.
 def get_data():
-    # Run in a loop until the main thread is terminated |> range(start: -{interval})
-    while True:
-        start = datetime.now().timestamp()
-        flux_query = f'''
+    # Run in a loop until the main thread is terminated
+    while run:
+        try:            
+            # Query InfluxDB 2.0 using flux
+            flux_query = f'''
             from(bucket: "{bucket}")
                 |> range(start: -{interval})
                 |> filter(fn: (r) => r._measurement == "{measurement}")
                 |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
             '''
-        influx_df = query_api.query_data_frame(query=flux_query,org=os.environ['INFLUXDB_ORG'])
+            logger.info(f"Sending query: {flux_query}")
 
-        # Convert Timestamp columns to ISO 8601 formatted strings to avoid serialization errors
-        datetime_cols = influx_df.select_dtypes(include=['datetime64[ns]', 'datetime64[ns, UTC]']).columns
-        for col in datetime_cols:
-            influx_df[col] = influx_df[col].dt.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            table = query_api.query_data_frame(query=flux_query,org=os.environ['INFLUXDB_ORG'])
 
-        # If the query returns tables with different schemas, the result will be a list of dataframes.
-        if isinstance(influx_df, list):
-            for item in influx_df:
-                yield item
-                print(f"Published 1 row to Quix")
-        elif isinstance(influx_df, pd.DataFrame) and not influx_df.empty:
-            yield influx_df
-            print(f"Published {len(influx_df)} rows to Quix")
+            # Renaming time column to distinguish it from other timestamp types
+            table.rename(columns={'_time': 'original_time'}, inplace=True)
 
-        # Wait for the next interval
-        wait_time = datetime.now().timestamp() - start + interval_seconds
-        if wait_time > 0:
-            sleep(wait_time)
-        else:
-            print(f"Warning: Query took longer than {interval} seconds. Skipping sleep.")
+            # If there are rows to write to the stream at this time
+            if not table.empty:
+                json_result = table.to_json(orient='records', date_format='iso')
+                yield json_result
+                print("query success")
+            else:
+                print("No new data to publish.")
+
+            # Wait for the next interval
+            sleep(interval_seconds)
+
+        except Exception as e:
+            print("query failed", flush=True)
+            print(f"error: {e}", flush=True)
+            sleep(1)
 
 def main():
     """
@@ -108,19 +111,17 @@ def main():
     producer = app.get_producer()
 
     with producer:
-    # Iterate over the data from query result
-        for df in get_data():
-
-            # Generate a unique message_key for each row
-            for index, row in df.iterrows():
-                message_key = f"INFLUX_DATA_{str(random.randint(1, 100)).zfill(3)}_{index}"
-
-                # Convert the row to a dictionary
-                row_data = row.to_dict()
+        for res in get_data():
+            # Parse the JSON string into a Python object
+            records = json.loads(res)
+            for index, obj in enumerate(records):
+                # Generate a unique message_key for each row
+                message_key = f"INFLUX2_DATA_{str(random.randint(1, 100)).zfill(3)}_{index}"
+                logger.info(f"Produced message with key:{message_key}, value:{obj}")
 
                 # Serialize row value to bytes
                 serialized_value = serializer(
-                    value=row_data, ctx=SerializationContext(topic=topic.name)
+                    value=obj, ctx=SerializationContext(topic=topic.name)
                 )
 
                 # publish the data to the topic

--- a/python/sources/InfluxDB-2.0/main.py
+++ b/python/sources/InfluxDB-2.0/main.py
@@ -108,9 +108,8 @@ def main():
     # Producer is already setup to use Quix brokers.
     # It will also ensure that the topics exist before producing to them if
     # Application.Quix is initialized with "auto_create_topics=True".
-    producer = app.get_producer()
-
-    with producer:
+  
+    with app.get_producer() as producer:
         for res in get_data():
             # Parse the JSON string into a Python object
             records = json.loads(res)

--- a/python/sources/InfluxDB-2.0/requirements.txt
+++ b/python/sources/InfluxDB-2.0/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==0.5.7
+quixstreams==2.2.0a0
 influxdb-client==1.39.0
 

--- a/python/sources/InfluxDB/library.json
+++ b/python/sources/InfluxDB/library.json
@@ -20,14 +20,14 @@
       "Type" : "EnvironmentVariable",
       "InputType" : "OutputTopic",
       "Description" : "This is the Quix topic that will receive the stream",
-      "DefaultValue" : "influxdb",
+      "DefaultValue" : "influxdbv3-data",
       "Required": true
   },
     {
       "Name": "task_interval",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
-      "Description": "Interval to run query. Must be within the InfluxDB notation; 1s, 1m, 1h, 1d, 1w, 1mo, 1y",
+      "Description": "Interval to run query. Must be within the InfluxDB notation; 1s, 1m, 1h, 1d, 1w, 1y",
       "DefaultValue": "5m",
       "Required": true
     },

--- a/python/sources/InfluxDB/main.py
+++ b/python/sources/InfluxDB/main.py
@@ -105,9 +105,8 @@ def main():
     # Producer is already setup to use Quix brokers.
     # It will also ensure that the topics exist before producing to them if
     # Application.Quix is initialized with "auto_create_topics=True".
-    producer = app.get_producer()
 
-    with producer:
+    with app.get_producer() as producer:
         for res in get_data():
             # Parse the JSON string into a Python object
             records = json.loads(res)

--- a/python/sources/InfluxDB/main.py
+++ b/python/sources/InfluxDB/main.py
@@ -69,11 +69,11 @@ def get_data():
     # Run in a loop until the main thread is terminated
     while run:
         try:
-            myquery = f'SELECT * FROM "{measurement_name}" WHERE time >= now() - {interval}'
-            print(f"sending query {myquery}")
+            query_definition = f'SELECT * FROM "{measurement_name}" WHERE time >= now() - {interval}'
+            print(f"Sending query {query_definition}")
             # Query InfluxDB 3.0 using influxql or sql
             table = influxdb3_client.query(
-                                    query=myquery,
+                                    query=query_definition,
                                     mode="pandas",
                                     language="influxql")
 

--- a/python/sources/InfluxDB/main.py
+++ b/python/sources/InfluxDB/main.py
@@ -69,7 +69,7 @@ def get_data():
     # Run in a loop until the main thread is terminated
     while run:
         try:
-            myquery = f'SELECT * FROM "10ms_activations" WHERE time >= now() - {interval}'
+            myquery = f'SELECT * FROM "{measurement_name}" WHERE time >= now() - {interval}'
             print(f"sending query {myquery}")
             # Query InfluxDB 3.0 using influxql or sql
             table = influxdb3_client.query(

--- a/python/sources/InfluxDB/requirements.txt
+++ b/python/sources/InfluxDB/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==2.2.0a0
+quixstreams>=2.3.1
 influxdb3-python==0.3.6

--- a/python/sources/InfluxDB/requirements.txt
+++ b/python/sources/InfluxDB/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==0.5.7
-influxdb3-python==0.3.0
+quixstreams==2.2.0a0
+influxdb3-python==0.3.6


### PR DESCRIPTION
Before we can land on InfluxDbs integrations page, we need to update our code samples to SDF.

I have converted the InfluxDB v3 input/output connections and the InfluxDB v2 input connector. 

I have tested the all connectors. They seem to work, but could do with a second pair of eyes.

NOTES:
* I was getting JSON serialization errors on the timestamp so I added logic to convert it to a string 
* The original v2 input connector (using Quix 0.5) was missing a measurement filter from the query, I dont understand how it possibly could have worked previously but running it without that filter (with Quix 2.0) gave me duplicate column errors, so I added a measurement filter — the old V3 connector already had a measurement filter too so I didnt have this problem when porting the V3 connectors,
  * Maybe this is intentional given that the InfluxDB2 connector is meant to migrate all data from V2 to V3, but the Influx client kept throwing errors about duplicate columns in the "result" Dataframe and I couldn't figure out how to fix it despite trying to catch the duplicates.