### PR TITLE
Improve influx samples

### DIFF
--- a/python/destinations/ConfluentKafka/requirements.txt
+++ b/python/destinations/ConfluentKafka/requirements.txt
@@ -1,2 +1,1 @@
 quixstreaming==0.4.10a202301271318
-paho-mqtt

--- a/python/destinations/InfluxDB/library.json
+++ b/python/destinations/InfluxDB/library.json
@@ -48,6 +48,14 @@
       "Required": false
     },
     {
+      "Name": "INFLUXDB_MEASUREMENT_NAME",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "The InfluxDB measurement to write data to. If not specified, the name of the input topic will be used",
+      "DefaultValue": "",
+      "Required": false
+    },
+    {
       "Name": "INFLUXDB_DATABASE",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
@@ -56,27 +64,27 @@
       "Required": true
     },
     {
-      "Name": "INFLUXDB_TAG_COLUMNS",
+      "Name": "INFLUXDB_TAG_KEYS",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
-      "Description": "Columns to be used as tags when writing data to InfluxDB.",
+      "Description": "The tags to include when writing the measurement data",
       "DefaultValue": "['tag1', 'tag2']",
       "Required": false
     },
-    {
-      "Name": "INFLUXDB_MEASUREMENT_NAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The InfluxDB measurement to write data to. If not specified, the name of the input topic will be used",
-      "DefaultValue": "",
-      "Required": false
-        },
     {
       "Name": "INFLUXDB_FIELD_KEYS",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
       "Description": "The fields to include when writing the measurement data",
       "DefaultValue": "['field1','field2']",
+      "Required": true
+    },
+    {
+      "Name": "CONSUMER_GROUP_NAME",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "The name of the consumer group to use when consuming from Kafka",
+      "DefaultValue": "influxdb-sink",
       "Required": true
     }
   ]

--- a/python/destinations/InfluxDB/library.json
+++ b/python/destinations/InfluxDB/library.json
@@ -20,7 +20,7 @@
       "Type": "EnvironmentVariable",
       "InputType": "InputTopic",
       "Description": "This is the input topic",
-      "DefaultValue": "detection-result",
+      "DefaultValue": "input-data",
       "Required": true
     },
     {

--- a/python/destinations/InfluxDB/main.py
+++ b/python/destinations/InfluxDB/main.py
@@ -11,21 +11,19 @@ from influxdb_client_3 import InfluxDBClient3
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+consumer_group_name = os.environ.get('CONSUMER_GROUP_NAME', "influxdb-data-writer")
 
-app = Application.Quix(consumer_group="influx-destination",
-                       auto_offset_reset="earliest")
+# Create a Quix platform-specific application instead
+app = Application.Quix(consumer_group=consumer_group_name, auto_create_topics=True, auto_offset_reset='earliest')
 
 input_topic = app.topic(os.environ["input"], value_deserializer=JSONDeserializer())
 
 # Read the environment variable and convert it to a dictionary
-tag_dict = ast.literal_eval(os.environ.get('INFLUXDB_TAG_COLUMNS', "{}"))
-
-# Read the environment variable for measurement name
-measurement_name = os.environ.get('INFLUXDB_MEASUREMENT_NAME', os.environ["input"])
+tag_keys = ast.literal_eval(os.environ.get('INFLUXDB_TAG_KEYS', "[]"))
+field_keys = ast.literal_eval(os.environ.get('INFLUXDB_FIELD_KEYS', "[]"))
 
 # Read the environment variable for the field(s) to get.
 # For multiple fields, use a list "['field1','field2']"
-field_keys = os.environ.get("INFLUXDB_FIELD_KEYS", "['field1','field2']")
                                            
 influx3_client = InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
                          host=os.environ["INFLUXDB_HOST"],
@@ -35,33 +33,43 @@ influx3_client = InfluxDBClient3(token=os.environ["INFLUXDB_TOKEN"],
 def send_data_to_influx(message):
     logger.info(f"Processing message: {message}")
     try:
-        quixtime = message['time']
-        # Get the name(s) and value(s) of the selected field(s)
-        # Using a single field in this example for simplicity
-        field1_name = field_keys[0]
-        field1_value = message[field_keys[0]]
+        # Get the measurement name to write data to
+        measurement_name = os.environ.get('INFLUXDB_MEASUREMENT_NAME', "measurement1")
 
-        logger.info(f"Using field keys: {', '.join(field_keys)}")
+        # Initialize the tags and fields dictionaries
+        tags = {}
+        fields = {}
 
-        # Using point dictionary structure
-        # See: https://docs.influxdata.com/influxdb/cloud-dedicated/reference/client-libraries/v3/python/#write-data-using-a-dict
+        # Iterate over the tag_dict and field_dict to populate tags and fields
+        for tag_key in tag_keys:
+            if tag_key in message:
+                tags[tag_key] = message[tag_key]
+
+        for field_key in field_keys:
+            if field_key in message:
+                fields[field_key] = message[field_key]
+
+        logger.info(f"Using tag keys: {', '.join(tags.keys())}")
+        logger.info(f"Using field keys: {', '.join(fields.keys())}")
+
+        # Construct the points dictionary
         points = {
             "measurement": measurement_name,
-            "tags": tag_dict,
-            "fields": {field1_name: field1_value},
-            "time": quixtime
+            "tags": tags,
+            "fields": fields,
+            "time": message['time']
         }
 
         influx3_client.write(record=points, write_precision="ms")
         
-        print(f"{str(datetime.datetime.utcnow())}: Persisted measurement to influx.")
+        logger.info(f"{str(datetime.datetime.utcnow())}: Persisted ponts to influx: {points}")
     except Exception as e:
-        print(f"{str(datetime.datetime.utcnow())}: Write failed")
-        print(e)
+        logger.info(f"{str(datetime.datetime.utcnow())}: Write failed")
+        logger.info(e)
 
 sdf = app.dataframe(input_topic)
 sdf = sdf.update(send_data_to_influx)
 
 if __name__ == "__main__":
-    print("Starting application")
+    logger.info("Starting application")
     app.run(sdf)

--- a/python/destinations/MQTT/requirements.txt
+++ b/python/destinations/MQTT/requirements.txt
@@ -1,2 +1,2 @@
 quixstreams==0.5.7
-paho-mqtt
+paho-mqtt==1.6.1

--- a/python/sources/InfluxDB-2.0/main.py
+++ b/python/sources/InfluxDB-2.0/main.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Create a Quix Application
-app = Application.Quix(consumer_group="influxdbv2_sample", auto_create_topics=True)
+app = Application.Quix(consumer_group="influxdbv2_source", auto_create_topics=True)
 
 # Define a serializer for messages, using JSON Serializer for ease
 serializer = JSONSerializer()
@@ -30,7 +30,6 @@ influxdb2_client = influxdb_client.InfluxDBClient(token=os.environ["INFLUXDB_TOK
 
 query_api = influxdb2_client.query_api()
 
-measurement = os.environ.get("INFLUXDB_MEASUREMENT_NAME", os.environ["output"])
 interval = os.environ.get("task_interval", "5m")
 bucket = os.environ.get("INFLUXDB_BUCKET", "placeholder-bucket")
 
@@ -63,6 +62,10 @@ def interval_to_seconds(interval: str) -> int:
 
 interval_seconds = interval_to_seconds(interval)
 
+
+def is_dataframe(result):
+    return type(result).__name__ == 'DataFrame'
+
 # Function to fetch data from InfluxDB and send it to Quix
 # It runs in a continuous loop, periodically fetching data based on the interval.
 def get_data():
@@ -73,7 +76,6 @@ def get_data():
             flux_query = f'''
             from(bucket: "{bucket}")
                 |> range(start: -{interval})
-                |> filter(fn: (r) => r._measurement == "{measurement}")
                 |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
             '''
             logger.info(f"Sending query: {flux_query}")
@@ -81,22 +83,30 @@ def get_data():
             table = query_api.query_data_frame(query=flux_query,org=os.environ['INFLUXDB_ORG'])
 
             # Renaming time column to distinguish it from other timestamp types
-            table.rename(columns={'_time': 'original_time'}, inplace=True)
+            # table.rename(columns={'_time': 'original_time'}, inplace=True)
 
-            # If there are rows to write to the stream at this time
-            if not table.empty:
-                json_result = table.to_json(orient='records', date_format='iso')
-                yield json_result
-                logger.info("query success")
-            else:
-                logger.info("No new data to publish.")
+            # If the query returns tables with different schemas, the result will be a list of dataframes.
+            if isinstance(table, list):
+                for item in table:
+                    item.rename(columns={'_time': 'original_time'}, inplace=True)
+                    json_result = item.to_json(orient='records', date_format='iso')
+                    yield json_result
+                    logger.info("Published multiple measurements to Quix")
+            elif is_dataframe(table) and len(table) > 0:
+                    table.rename(columns={'_time': 'original_time'}, inplace=True)
+                    json_result = table.to_json(orient='records', date_format='iso')
+                    yield json_result
+                    logger.info("Published single measurement to Quix")
+            elif is_dataframe(table) and len(table) < 1:
+                    logger.info("No results.")
 
-            # Wait for the next interval
+            logger.info(f"Trying again in {interval_seconds} seconds...")
             sleep(interval_seconds)
 
         except Exception as e:
-            logger.info("query failed", flush=True)
-            logger.info(f"error: {e}", flush=True)
+            logger.info("query failed")
+            logger.info(f"error: {e}")
+            flush=True
             sleep(1)
 
 def main():
@@ -108,8 +118,9 @@ def main():
     # Producer is already setup to use Quix brokers.
     # It will also ensure that the topics exist before producing to them if
     # Application.Quix is initialized with "auto_create_topics=True".
-  
-    with app.get_producer() as producer:
+    producer = app.get_producer()
+
+    with producer:
         for res in get_data():
             # Parse the JSON string into a Python object
             records = json.loads(res)

--- a/python/sources/InfluxDB/main.py
+++ b/python/sources/InfluxDB/main.py
@@ -112,7 +112,8 @@ def main():
             records = json.loads(res)
             for index, obj in enumerate(records):
                 # Generate a unique message_key for each row
-                message_key = f"INFLUX_DATA_{str(random.randint(1, 100)).zfill(3)}_{index}" # Change to a tag name if you want to aggregate data by a specific tag such as "SensorID"
+                # Change to a tag name if you want to aggregate data by a specific tag such as "SensorID"—e.g. message_key = obj['SensorID']
+                message_key = f"INFLUX_DATA_{str(random.randint(1, 100)).zfill(3)}_{index}" 
                 logger.info(f"Produced message with key:{message_key}, value:{obj}")
 
                 # Serialize row value to bytes

--- a/python/sources/InfluxDB/main.py
+++ b/python/sources/InfluxDB/main.py
@@ -112,7 +112,7 @@ def main():
             records = json.loads(res)
             for index, obj in enumerate(records):
                 # Generate a unique message_key for each row
-                message_key = f"INFLUX_DATA_{str(random.randint(1, 100)).zfill(3)}_{index}"
+                message_key = f"INFLUX_DATA_{str(random.randint(1, 100)).zfill(3)}_{index}" # Change to a tag name if you want to aggregate data by a specific tag such as "SensorID"
                 logger.info(f"Produced message with key:{message_key}, value:{obj}")
 
                 # Serialize row value to bytes

--- a/python/sources/MQTT/requirements.txt
+++ b/python/sources/MQTT/requirements.txt
@@ -1,2 +1,2 @@
 quixstreams==0.5.7
-paho-mqtt
+paho-mqtt==1.6.1

--- a/python/transformations/starter-transformation/main.py
+++ b/python/transformations/starter-transformation/main.py
@@ -6,9 +6,6 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-print(os.environ["input"])
-
-
 with open("./.env", 'a+') as file: pass  # make sure the .env file exists
 load_dotenv("./.env")
 


### PR DESCRIPTION
This PR is mostly to improve the InfluxDBV2 source connector which required you to specific a measurement when reading the data, when the assumption is that the user is trying to migrate data out of influxdbV2 and therefore wants to get all measurements in one go.

The flux query has been updated to get all measurements. I also updated the dataframe check to not require importing pandas, although its still needed in the requirements file.

However, there are also minor tweaks to the V3 source and destination samples, sauch as adding the consumer group name as an env var, so you don't have to keep changing it in the code if you're testing (it has a default if the user doesnt want to think about it)