### PR TITLE
Transformations: Quix Configuration Enricher

### DIFF
--- a/python/transformations/quix_configuration_enricher/README.md
+++ b/python/transformations/quix_configuration_enricher/README.md
@@ -5,8 +5,6 @@ enrich your data using a `Quix Configuration Service` (through a topic managed b
 
 ## How to run
 
-## How to run
-
 Create a [Quix](https://portal.platform.quix.io/signup?xlink=github) account or log-in and visit the Samples to use this project.
 
 Clicking `Edit code` on the Sample, forks the project to your own Git repo so you can customize it before deploying.

--- a/python/transformations/quix_configuration_enricher/README.md
+++ b/python/transformations/quix_configuration_enricher/README.md
@@ -1,7 +1,23 @@
 # Quix Configuration Enricher
 
 [This code sample](https://github.com/quixio/quix-samples/tree/main/python/transformations/quix_configuration_enricher) demonstrates how to 
-enrich your data using a `Quix Configuration Service` (through a topic managed by the service).
+enrich your data using configuration data stored with 
+`Quix Configuration Service` (through a topic managed by the service).
+
+## App Details
+
+This template deploys a simple enricher using the Quix Streams `QuixConfigurationService`, 
+which enriches through a record join that adds fields specified by the user in the
+LOOKUP_FIELDS_JSON environment variable.
+
+The join is achieved by retrieving configs from a specified topic maintained by a
+**Quix Configuration Service** deployment.
+
+The **Quix Configuration Service** deployment helps manage versioning of configs,
+and the Quix Streams `QuixConfigurationService` helps streamline interacting with it.
+
+The respective config applied is based on a combination of message key and the config "type"
+specified.
 
 ## How to run
 
@@ -26,7 +42,7 @@ The connector uses the following environment variables:
 
 ## Requirements / Prerequisites
 
-You will need to have a `Quix Configuration Service` instance running and any desired
+You will need to have a **Quix Configuration Service** instance running and any desired
 configurations actively available on its corresponding topic.
 
 ## Contribute

--- a/python/transformations/quix_configuration_enricher/README.md
+++ b/python/transformations/quix_configuration_enricher/README.md
@@ -24,11 +24,7 @@ The connector uses the following environment variables:
 
 ### Optional
 - **CONSUMER_GROUP_NAME**: The name of the consumer group to use when consuming from Kafka.  
-  Default: `postgres-sink`
-- **BATCH_SIZE**: The number of records that the sink holds before flushing data to PostgreSQL.  
-  Default: `1000`
-- **BATCH_TIMEOUT**: The number of seconds that the sink holds before flushing data to PostgreSQL.  
-  Default: `1`
+  Default: `quix-configuration-enricher`
 
 ## Requirements / Prerequisites
 

--- a/python/transformations/quix_configuration_enricher/README.md
+++ b/python/transformations/quix_configuration_enricher/README.md
@@ -1,0 +1,44 @@
+# Quix Configuration Enricher
+
+[This code sample](https://github.com/quixio/quix-samples/tree/main/python/transformations/quix_configuration_enricher) demonstrates how to 
+enrich your data using a `Quix Configuration Service` (through a topic managed by the service).
+
+## How to run
+
+## How to run
+
+Create a [Quix](https://portal.platform.quix.io/signup?xlink=github) account or log-in and visit the Samples to use this project.
+
+Clicking `Edit code` on the Sample, forks the project to your own Git repo so you can customize it before deploying.
+
+## Environment Variables
+
+The connector uses the following environment variables:
+
+### Required
+- **DATA_TOPIC**: The topic containing your data to be enriched.
+- **CONFIG_TOPIC**: The topic managed by your Quix Configuration Service.
+- **OUTPUT_TOPIC**: The topic to write the enriched data to.
+- **LOOKUP_FIELDS_JSON**: a JSON-serialized string that contains the desired field names with corresponding config field references.  
+  ex: `{"f1": {"type": "cfg-name", "default": "value", "jsonpath": "path.to.f1"}, "f2": {"type": "cfg-name", "default": null, "jsonpath": "path.to.f2"}}`
+
+### Optional
+- **CONSUMER_GROUP_NAME**: The name of the consumer group to use when consuming from Kafka.  
+  Default: `postgres-sink`
+- **BATCH_SIZE**: The number of records that the sink holds before flushing data to PostgreSQL.  
+  Default: `1000`
+- **BATCH_TIMEOUT**: The number of seconds that the sink holds before flushing data to PostgreSQL.  
+  Default: `1`
+
+## Requirements / Prerequisites
+
+You will need to have a `Quix Configuration Service` instance running and any desired
+configurations actively available on its corresponding topic.
+
+## Contribute
+
+Submit forked projects to the Quix [GitHub](https://github.com/quixio/quix-samples) repo. Any new project that we accept will be attributed to you, and you'll receive $200 in Quix credit.
+
+## Open Source
+
+This project is open source under the Apache 2.0 license and available in our [GitHub](https://github.com/quixio/quix-samples) repo. Please star us and mention us on social media to show your appreciation.

--- a/python/transformations/quix_configuration_enricher/dockerfile
+++ b/python/transformations/quix_configuration_enricher/dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12.5-slim-bookworm
+			
+# Set environment variables for non-interactive setup and unbuffered output
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    PYTHONPATH="/app"
+			
+# Build argument for setting the main app path
+ARG MAINAPPPATH=.
+			
+# Set working directory inside the container
+WORKDIR /app
+			
+# Copy requirements to leverage Docker cache
+COPY "${MAINAPPPATH}/requirements.txt" "${MAINAPPPATH}/requirements.txt"
+			
+# Install dependencies without caching
+RUN pip install --no-cache-dir -r "${MAINAPPPATH}/requirements.txt"
+			
+# Copy entire application into container
+COPY . .
+			
+# Set working directory to main app path
+WORKDIR "/app/${MAINAPPPATH}"
+			
+# Define the container's startup command
+ENTRYPOINT ["python3", "main.py"]

--- a/python/transformations/quix_configuration_enricher/library.json
+++ b/python/transformations/quix_configuration_enricher/library.json
@@ -4,8 +4,8 @@
   "language": "Python",
   "tags": {
     "Pipeline Stage": ["Transformation"],
-    "Type": ["Connectors"],
-    "Category": ["Quix Configuration"]
+    "Type": ["Code samples"],
+    "Category": ["Quix Configuration Service"]
   },
   "shortDescription": "Consume data from a Kafka topic and enrich it using a Quix Configuration Service topic.",
   "DefaultFile": "main.py",

--- a/python/transformations/quix_configuration_enricher/library.json
+++ b/python/transformations/quix_configuration_enricher/library.json
@@ -1,0 +1,76 @@
+{
+  "libraryItemId": "quix-configuration-enricher",
+  "name": "Quix Configuration Enricher",
+  "language": "Python",
+  "tags": {
+    "Pipeline Stage": ["Transformation"],
+    "Type": ["Connectors"],
+    "Category": ["Quix Configuration"]
+  },
+  "shortDescription": "Consume data from a Kafka topic and enrich it using a Quix Configuration Service topic.",
+  "DefaultFile": "main.py",
+  "EntryPoint": "dockerfile",
+  "RunEntryPoint": "main.py",
+  "Variables": [
+    {
+      "Name": "DATA_TOPIC",
+      "Type": "EnvironmentVariable",
+      "InputType": "InputTopic",
+      "Description": "The topic containing your data to be enriched.",
+      "Required": true
+    },
+    {
+      "Name": "CONFIG_TOPIC",
+      "Type": "EnvironmentVariable",
+      "InputType": "InputTopic",
+      "Description": "The topic managed by your Quix Configuration Service.",
+      "Required": true
+    },
+    {
+      "Name": "OUTPUT_TOPIC",
+      "Type": "EnvironmentVariable",
+      "InputType": "OutputTopic",
+      "Description": "The topic to write the enriched data to.",
+      "Required": true
+    },
+    {
+      "Name": "LOOKUP_FIELDS_JSON",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "a JSON-serialized string that contains the desired field names with corresponding config field references. See 'get_fields' function in code for example.",
+      "Required": true
+    },
+    {
+      "Name": "CONSUMER_GROUP_NAME",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "The name of the consumer group to use when consuming from Kafka",
+      "DefaultValue": "postgres-sink",
+      "Required": true
+    },
+    {
+      "Name": "BATCH_SIZE",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "The number of records that the sink holds before flushing data to PostgreSQL.",
+      "DefaultValue": "1000",
+      "Required": false
+    },
+    {
+      "Name": "BATCH_TIMEOUT",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "The number of seconds that the sink holds before flushing data to PostgreSQL.",
+      "DefaultValue": "1",
+      "Required": false
+    }
+  ],
+  "DeploySettings": {
+    "DeploymentType": "Service",
+    "CpuMillicores": 200,
+    "MemoryInMb": 500,
+    "Replicas": 1,
+    "PublicAccess": false,
+    "ValidateConnection": true
+  }
+}

--- a/python/transformations/quix_configuration_enricher/library.json
+++ b/python/transformations/quix_configuration_enricher/library.json
@@ -38,6 +38,7 @@
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
       "Description": "a JSON-serialized string that contains the desired field names with corresponding config field references. See 'get_fields' function in code for example.",
+      "Multiline": true,
       "Required": true
     },
     {
@@ -45,24 +46,8 @@
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
       "Description": "The name of the consumer group to use when consuming from Kafka",
-      "DefaultValue": "postgres-sink",
+      "DefaultValue": "quix-configuration-enricher",
       "Required": true
-    },
-    {
-      "Name": "BATCH_SIZE",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The number of records that the sink holds before flushing data to PostgreSQL.",
-      "DefaultValue": "1000",
-      "Required": false
-    },
-    {
-      "Name": "BATCH_TIMEOUT",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The number of seconds that the sink holds before flushing data to PostgreSQL.",
-      "DefaultValue": "1",
-      "Required": false
     }
   ],
   "DeploySettings": {

--- a/python/transformations/quix_configuration_enricher/main.py
+++ b/python/transformations/quix_configuration_enricher/main.py
@@ -25,15 +25,15 @@ def get_fields():
 
 def main():
     """
-    This template deploys a simple enricher using the QuixConfigurationService, which
-    enriches by performing a join by adding fields specified by the user in the
+    This template deploys a simple enricher using the Quix Streams `QuixConfigurationService`,
+    which enriches through a record join that adds fields specified by the user in the
     LOOKUP_FIELDS_JSON environment variable.
 
-    The join is achieved by retrieves configs from a specified topic maintained by a
-    `Quix Dynamic Configuration Service`.
+    The join is achieved by retrieving configs from a specified topic maintained by a
+    Quix Configuration Service deployment.
 
-    The `Quix Dynamic Configuration Service` itself helps manage versioning of configs,
-    and the QuixConfigurationService helps streamline interacting with it.
+    The Quix Configuration Service deployment helps manage versioning of configs,
+    and the Quix Streams `QuixConfigurationService` helps streamline interacting with it.
 
     The respective config applied is based on a combination of message key and the config "type"
     specified.

--- a/python/transformations/quix_configuration_enricher/main.py
+++ b/python/transformations/quix_configuration_enricher/main.py
@@ -47,6 +47,7 @@ def main():
     sdf = app.dataframe(topic=data_topic)
 
     # Enrich data using the config service (lookup_join)
+    # Other transformations could be added here if desired.
     sdf = sdf.join_lookup(
         lookup=QuixConfigurationService(
             topic=config_topic,

--- a/python/transformations/quix_configuration_enricher/main.py
+++ b/python/transformations/quix_configuration_enricher/main.py
@@ -39,12 +39,7 @@ def main():
     specified.
     """
 
-    app = Application(
-        consumer_group=os.environ["CONSUMER_GROUP_NAME"],
-        auto_offset_reset="earliest",
-        commit_interval=float(os.environ.get("BATCH_TIMEOUT", "1")),
-        commit_every=int(os.environ.get("BATCH_SIZE", "1000"))
-    )
+    app = Application(consumer_group=os.environ["CONSUMER_GROUP_NAME"])
 
     data_topic = app.topic(name=os.environ["DATA_TOPIC"], key_deserializer="str")
     config_topic = app.topic(name=os.environ["CONFIG_TOPIC"])

--- a/python/transformations/quix_configuration_enricher/main.py
+++ b/python/transformations/quix_configuration_enricher/main.py
@@ -1,0 +1,70 @@
+import os
+import json
+
+from quixstreams.dataframe.joins.lookups.quix_configuration_service import QuixConfigurationService
+from quixstreams.dataframe.joins.lookups.quix_configuration_service.lookup import JSONField
+from quixstreams import Application
+
+
+def get_fields():
+    """
+    The LOOKUP_FIELDS_JSON should be a JSON formatted like this example:
+    {
+        "f1": {"type": "cfg-name", "default": "value", "jsonpath": "path.to.f1"},
+        "f2": {"type": "cfg-name", "default": null, "jsonpath": "path.to.f2"},
+        "f3": {"type": "cfg-name", "default": 1.0, "jsonpath": "path.to.f3"},
+    }
+
+    If this environment-based approach is too restrictive, replace it with custom logic.
+    """
+    return {
+        field_name: JSONField(**field)
+        for field_name, field in json.loads(os.environ["LOOKUP_FIELDS_JSON"]).items()
+    }
+
+
+def main():
+    """
+    This template deploys a simple enricher using the QuixConfigurationService, which
+    enriches by performing a join by adding fields specified by the user in the
+    LOOKUP_FIELDS_JSON environment variable.
+
+    The join is achieved by retrieves configs from a specified topic maintained by a
+    `Quix Dynamic Configuration Service`.
+
+    The `Quix Dynamic Configuration Service` itself helps manage versioning of configs,
+    and the QuixConfigurationService helps streamline interacting with it.
+
+    The respective config applied is based on a combination of message key and the config "type"
+    specified.
+    """
+
+    app = Application(
+        consumer_group=os.environ["CONSUMER_GROUP_NAME"],
+        auto_offset_reset="earliest",
+        commit_interval=float(os.environ.get("BATCH_TIMEOUT", "1")),
+        commit_every=int(os.environ.get("BATCH_SIZE", "1000"))
+    )
+
+    data_topic = app.topic(name=os.environ["DATA_TOPIC"], key_deserializer="str")
+    config_topic = app.topic(name=os.environ["CONFIG_TOPIC"])
+    output_topic = app.topic(name=os.environ["OUTPUT_TOPIC"])
+    sdf = app.dataframe(topic=data_topic)
+
+    # Enrich data using the config service (lookup_join)
+    sdf = sdf.join_lookup(
+        lookup=QuixConfigurationService(
+            topic=config_topic,
+            app_config=app.config,
+        ),
+        fields=get_fields()
+    )
+
+    # Finish off by writing to the final result to the output topic
+    sdf.to_topic(output_topic)
+    # With our pipeline defined, now run the Application
+    app.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/python/transformations/quix_configuration_enricher/requirements.txt
+++ b/python/transformations/quix_configuration_enricher/requirements.txt
@@ -1,0 +1,2 @@
+quixstreams==3.22.0
+python-dotenv


### PR DESCRIPTION
A simple example using the `QuixConfigurationService` with a way of loading the set of fields using a json-serialized env var, including a multiline env var, like so:

```
      - name: LOOKUP_FIELDS_JSON
        inputType: FreeText
        description: a JSON-serialized string that contains the desired field names with corresponding config field references. See 'get_fields' function in code for example.
        multiline: true
        value: |
          {
            "editor_name": {"type": "printer-config", "default": null, "jsonpath": "editor_name"},
            "field_scalar": {"type": "printer-config", "default": 1.0, "jsonpath": "field_scalar"},
            "mapping": {"type": "printer-config", "default": {}, "jsonpath": "mapping"}
          }
```