### PR TITLE
Add stream timeout support to Quixlake timeseries destination [sc-72221]

### DIFF
--- a/python/destinations/quixlake-timeseries/README.md
+++ b/python/destinations/quixlake-timeseries/README.md
@@ -79,6 +79,21 @@ Then either:
 - **`MAX_WRITE_WORKERS`**: How many files can be written in parallel to storage at once
   *Default*: `10`
 
+### Stream Timeout
+
+Detects silent Kafka message keys and emits a one-shot event so downstream consumers know a stream has gone quiet.
+
+- **`STREAM_TIMEOUT_TOPIC`**: Topic where timeout events are produced. Set to an empty string to disable the feature entirely.
+  *Default*: `timeout-topic`
+
+- **`STREAM_TIMEOUT_SECONDS`**: Per-key inactivity threshold. If a key receives no messages for this many seconds, a single timeout event is emitted. Values below `COMMIT_INTERVAL + 1` are automatically saturated to that minimum.
+  *Default*: `60`
+
+Emitted payload (value is JSON-encoded, key is the stream name as UTF-8 bytes):
+```json
+{"ts_ms": 1714000000000, "stream": "<kafka-key>", "event": "stream_timeout"}
+```
+
 ### Application Settings
 
 - **`LOGLEVEL`**: Set application logging level

--- a/python/destinations/quixlake-timeseries/README.md
+++ b/python/destinations/quixlake-timeseries/README.md
@@ -89,10 +89,12 @@ Detects silent Kafka message keys and emits a one-shot event so downstream consu
 - **`STREAM_TIMEOUT_SECONDS`**: Per-key inactivity threshold. If a key receives no messages for this many seconds, a single timeout event is emitted. Values below `COMMIT_INTERVAL + 1` are automatically saturated to that minimum.
   *Default*: `60`
 
-Emitted payload (value is JSON-encoded, key is the stream name as UTF-8 bytes):
-```json
-{"ts_ms": 1714000000000, "stream": "<kafka-key>", "event": "stream_timeout"}
-```
+Emitted record shape:
+- **Kafka record key** — raw pass-through of the silent input key (the exact bytes that arrived on the input topic).
+- **Kafka record value** — JSON envelope (the `stream` field is UTF-8-decoded from the key for JSON-serializability):
+  ```json
+  {"ts_ms": 1714000000000, "stream": "<kafka-key>", "event": "stream_timeout"}
+  ```
 
 ### Application Settings
 

--- a/python/destinations/quixlake-timeseries/library.json
+++ b/python/destinations/quixlake-timeseries/library.json
@@ -171,6 +171,20 @@
       "InputType": "FreeText",
       "Description": "How many files can be written in parallel to storage at once (based on partitioning + batch size)",
       "DefaultValue": "10"
+    },
+    {
+      "Name": "STREAM_TIMEOUT_TOPIC",
+      "Type": "EnvironmentVariable",
+      "InputType": "OutputTopic",
+      "Description": "Topic to emit stream-timeout events on. Set to empty string to disable the feature.",
+      "DefaultValue": "timeout-topic"
+    },
+    {
+      "Name": "STREAM_TIMEOUT_SECONDS",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "Per-key inactivity threshold in seconds. Saturated to COMMIT_INTERVAL + 1 s if lower.",
+      "DefaultValue": "60"
     }
   ],
   "DeploySettings": {

--- a/python/destinations/quixlake-timeseries/main.py
+++ b/python/destinations/quixlake-timeseries/main.py
@@ -11,9 +11,12 @@ automatically from this configuration.
 File paths follow the workspace-aware structure:
     {workspaceId}/data-lake/time-series/{table_name}/...
 """
+import json
 import os
 import re
+import time
 import logging
+from typing import Optional, Callable
 
 from quixstreams import Application
 from quixstreams.sinks.core.quix_ts_datalake_sink import QuixTSDataLakeSink
@@ -59,10 +62,11 @@ def parse_hive_columns(columns_str: str) -> list:
 
 
 # Initialize Quix Streams Application
+commit_interval = _positive_int("COMMIT_INTERVAL", "30")
 app = Application(
     consumer_group=os.getenv("CONSUMER_GROUP", "s3_direct_sink_v1.0"),
     auto_offset_reset=os.getenv("AUTO_OFFSET_RESET", "latest"),
-    commit_interval=_positive_int("COMMIT_INTERVAL", "30"),
+    commit_interval=commit_interval,
     commit_every=_positive_int("BATCH_SIZE", "1000")
 )
 
@@ -78,6 +82,86 @@ if not _TABLE_NAME_PATTERN.match(table_name):
 
 # Workspace ID (automatically injected by Quix platform)
 workspace_id = os.getenv("Quix__Workspace__Id", "")
+
+# ---------------------------------------------------------------------------
+# Stream-timeout wiring
+#
+# A "stream" is one Kafka message key; silence is tracked per key inside
+# the sink and the callback is invoked once per silent key. This callback
+# runs on the sink thread during flush().
+#
+# Both env vars have defaults, so the feature is ON by default:
+#   STREAM_TIMEOUT_SECONDS = 60
+#   STREAM_TIMEOUT_TOPIC   = "timeout-topic"
+# Operators disable explicitly by setting STREAM_TIMEOUT_TOPIC="" (empty string);
+# unset falls through to the default.
+# ---------------------------------------------------------------------------
+stream_timeout_topic_name = os.environ.get("STREAM_TIMEOUT_TOPIC", "timeout-topic").strip()
+stream_timeout_ms: Optional[int]
+on_stream_timeout: Optional[Callable[[str], None]]
+side_producer = None
+
+if stream_timeout_topic_name:
+    side_producer = app.get_producer()
+    _min_timeout_ms = (commit_interval + 1) * 1000
+    stream_timeout_ms = _positive_int("STREAM_TIMEOUT_SECONDS", "60") * 1000
+    if stream_timeout_ms < _min_timeout_ms:
+        logger.warning(
+            "STREAM_TIMEOUT_SECONDS too low (%d ms); saturating to commit_interval + 1 s (%d ms)",
+            stream_timeout_ms,
+            _min_timeout_ms,
+        )
+        stream_timeout_ms = _min_timeout_ms
+    # Register the topic with the Application's topic manager. Under
+    # QuixTopicManager this fetches-or-creates the topic via the Quix API
+    # and rewrites `.name` to the workspace-prefixed broker name
+    # (`<workspace_id>-<name>`), which is what we must pass to the
+    # Producer.produce(topic=...) call below. Raw bytes serializers keep
+    # the hand-encoded key/value bytes flowing through unchanged.
+    stream_timeout_topic = app.topic(
+        stream_timeout_topic_name,
+        key_serializer="bytes",
+        value_serializer="bytes",
+    )
+    def on_stream_timeout(stream: str) -> None:
+        """Timeout handler for one silent Kafka message key.
+
+        The sink passes the decoded message key (a str) once that key has
+        been silent past the threshold. Logs INFO and produces one Kafka
+        message to STREAM_TIMEOUT_TOPIC with payload:
+            value = {"ts_ms": <wall-clock-ms>, "stream": <key>,
+                     "event": "stream_timeout"}
+        The Kafka record key is the UTF-8 bytes of ``stream``.
+
+        Fire-and-forget: this callback runs on the sink's flush thread
+        (which is the Application processing thread). Calling a blocking
+        ``side_producer.flush()`` here would stop the consumer from
+        polling for up to librdkafka's ``message.timeout.ms`` (~5 min
+        default), triggering a rebalance and offset-reset cascade. The
+        underlying producer polls in the background, so the message is
+        delivered asynchronously; we only need ``produce()``.
+        """
+        logger.info("Stream %s timed out after inactivity", stream)
+        side_producer.produce(
+            topic=stream_timeout_topic.name,
+            key=stream.encode() if isinstance(stream, str) else stream,
+            value=json.dumps({
+                "ts_ms": int(time.time() * 1000),
+                "stream": stream,
+                "event": "stream_timeout",
+            }).encode(),
+        )
+        # DO NOT call side_producer.flush() here — see docstring above.
+else:
+    stream_timeout_ms = None
+    on_stream_timeout = None
+
+logger.info(
+    "Stream-timeout tracking: %s",
+    f"enabled ({stream_timeout_ms} ms → topic {stream_timeout_topic_name!r})"
+    if stream_timeout_ms is not None
+    else "disabled",
+)
 
 # Initialize QuixLakeSink
 # Note: Blob storage credentials are configured via Quix__BlobStorage__Connection__Json
@@ -95,6 +179,8 @@ blob_sink = QuixTSDataLakeSink(
     namespace=os.getenv("CATALOG_NAMESPACE", "default"),
     auto_create_bucket=True,
     max_workers=_positive_int("MAX_WRITE_WORKERS", "10"),
+    stream_timeout_ms=stream_timeout_ms,
+    on_stream_timeout=on_stream_timeout,
     on_client_connect_success=lambda: print("CONNECTED!"),
     on_client_connect_failure=lambda e: print(f"ERROR! {e}"),
 )
@@ -113,4 +199,10 @@ logger.info(f"  Storage path: {storage_path}/{table_name}")
 logger.info(f"  Partitioning: {hive_columns if hive_columns else 'none'}")
 
 if __name__ == "__main__":
-    app.run()
+    if side_producer is not None:
+        side_producer.__enter__()
+    try:
+        app.run()
+    finally:
+        if side_producer is not None:
+            side_producer.__exit__(None, None, None)

--- a/python/destinations/quixlake-timeseries/main.py
+++ b/python/destinations/quixlake-timeseries/main.py
@@ -16,7 +16,7 @@ import os
 import re
 import time
 import logging
-from typing import Optional, Callable
+from typing import Any, Optional, Callable
 
 from quixstreams import Application
 from quixstreams.sinks.core.quix_ts_datalake_sink import QuixTSDataLakeSink
@@ -98,7 +98,7 @@ workspace_id = os.getenv("Quix__Workspace__Id", "")
 # ---------------------------------------------------------------------------
 stream_timeout_topic_name = os.environ.get("STREAM_TIMEOUT_TOPIC", "timeout-topic").strip()
 stream_timeout_ms: Optional[int]
-on_stream_timeout: Optional[Callable[[str], None]]
+on_stream_timeout: Optional[Callable[[Any], None]]
 side_producer = None
 
 if stream_timeout_topic_name:
@@ -123,15 +123,15 @@ if stream_timeout_topic_name:
         key_serializer="bytes",
         value_serializer="bytes",
     )
-    def on_stream_timeout(stream: str) -> None:
+    def on_stream_timeout(stream: Any) -> None:
         """Timeout handler for one silent Kafka message key.
 
-        The sink passes the decoded message key (a str) once that key has
-        been silent past the threshold. Logs INFO and produces one Kafka
-        message to STREAM_TIMEOUT_TOPIC with payload:
-            value = {"ts_ms": <wall-clock-ms>, "stream": <key>,
-                     "event": "stream_timeout"}
-        The Kafka record key is the UTF-8 bytes of ``stream``.
+        Record shape:
+        - ``key``: raw ``stream`` bytes from Kafka, pass-through (unchanged).
+        - ``value``: JSON object with event metadata and a decoded-for-
+          JSON copy of the stream identifier:
+            {"ts_ms": <wall-clock-ms>, "stream": <key-as-str>,
+             "event": "stream_timeout"}
 
         Fire-and-forget: this callback runs on the sink's flush thread
         (which is the Application processing thread). Calling a blocking
@@ -141,13 +141,17 @@ if stream_timeout_topic_name:
         underlying producer polls in the background, so the message is
         delivered asynchronously; we only need ``produce()``.
         """
-        logger.info("Stream %s timed out after inactivity", stream)
+        if isinstance(stream, bytes):
+            stream_str = stream.decode("utf-8", errors="replace")
+        else:
+            stream_str = str(stream)
+        logger.info("Stream %s timed out after inactivity", stream_str)
         side_producer.produce(
             topic=stream_timeout_topic.name,
-            key=stream.encode() if isinstance(stream, str) else stream,
+            key=stream,
             value=json.dumps({
                 "ts_ms": int(time.time() * 1000),
-                "stream": stream,
+                "stream": stream_str,
                 "event": "stream_timeout",
             }).encode(),
         )

--- a/python/destinations/quixlake-timeseries/requirements.txt
+++ b/python/destinations/quixlake-timeseries/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams[quixdatalake]>=3.23.6
+quixstreams[quixdatalake] @ git+https://github.com/quixio/quix-streams.git@91c1bbef120ab00080cde5aa5205f68e029fc131
 python-dotenv
 
 # Blob storage support via quixportal (AWS S3, Azure, GCP, MinIO)


### PR DESCRIPTION
Introduced the ability to detect inactive Kafka message keys and emit timeout events to a designated topic. This includes new configuration options for timeout thresholds and target topics, a side-producer to handle event emission, and updated documentation for the feature.