### PR TITLE
Add QuixLake environment variables to QuixLab

### DIFF
--- a/python/others/quixlab/library.json
+++ b/python/others/quixlab/library.json
@@ -68,6 +68,20 @@
       "Description": "Run mode: 'app' (view only) or 'edit' (full editor)",
       "DefaultValue": "edit",
       "Required": false
+    },
+    {
+      "Name": "QUIX_LAKE_URL",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "Base URL of the QuixLake instance to query against (e.g. https://quixlake-<workspace>.deployments.quix.io). Required for ql.sql() to work outside the default dev environment.",
+      "Required": true
+    },
+    {
+      "Name": "QUIX_LAKE_TOKEN",
+      "Type": "EnvironmentVariable",
+      "InputType": "Secret",
+      "Description": "Override token for QuixLake queries. Leave empty to use the platform-injected Quix__Sdk__Token.",
+      "Required": false
     }
   ]
 }


### PR DESCRIPTION
Add QUIX_LAKE_URL and QUIX_LAKE_TOKEN to the library configuration to enable SQL queries against QuixLake instances, allowing QuixLab to function outside the default development environment.