### PR TITLE
Quix-72287: Use injected Quix Lake URL in Marimo sample

### DIFF
--- a/python/destinations/quixlake-timeseries/library.json
+++ b/python/destinations/quixlake-timeseries/library.json
@@ -24,29 +24,26 @@
       "Type": "EnvironmentVariable",
       "InputType": "InputTopic",
       "Description": "Name of the Kafka input topic to consume from",
-      "DefaultValue": "tsbs_data_transformed",
       "Required": true
     },
     {
       "Name": "TABLE_NAME",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
-      "Description": "Table name for data organization and registration, else defaults to topic name",
-      "DefaultValue": "sensordata"
+      "Description": "Table name for data organization and registration. Leave empty to use the input topic name."
     },
     {
       "Name": "HIVE_COLUMNS",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
-      "Description": "Comma-separated list of columns for Hive partitioning. Include year/month/day/hour to extract from TIMESTAMP_COLUMN (e.g., location,year,month,day,sensor_type)",
-      "DefaultValue": "region,datacenter,hostname"
+      "Description": "Comma-separated list of columns for Hive partitioning (e.g. region,datacenter,hostname OR year,month,day extracted from TIMESTAMP_COLUMN). Leave empty for no Hive partitioning — every column listed here must exist in the incoming message payload, otherwise writes will fail."
     },
     {
       "Name": "TIMESTAMP_COLUMN",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
-      "Description": "Column containing timestamp values to extract year/month/day/hour from",
-      "DefaultValue": "ts_ms"
+      "Description": "Column containing timestamp values to extract year/month/day/hour from (only used when HIVE_COLUMNS includes one of those time components).",
+      "DefaultValue": "timestamp"
     },
     {
       "Name": "AUTO_DISCOVER",

--- a/python/destinations/quixlake-timeseries/library.json
+++ b/python/destinations/quixlake-timeseries/library.json
@@ -49,18 +49,6 @@
       "DefaultValue": "ts_ms"
     },
     {
-      "Name": "CATALOG_URL",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "REST Catalog URL for optional table registration (leave empty to skip)"
-    },
-    {
-      "Name": "CATALOG_AUTH_TOKEN",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "If using a catalog, the respective auth token to access it"
-    },
-    {
       "Name": "AUTO_DISCOVER",
       "Type": "EnvironmentVariable",
       "InputType": "Options",

--- a/python/destinations/quixlake-timeseries/main.py
+++ b/python/destinations/quixlake-timeseries/main.py
@@ -58,8 +58,11 @@ def parse_hive_columns(columns_str: str) -> list:
     return [col.strip() for col in columns_str.split(",") if col.strip()]
 
 
-# Initialize Quix Streams Application
+# Initialize Quix Streams Application. `broker_address` is read from KAFKA_BOOTSTRAP_SERVERS for
+# local-dev convenience; in Quix Cloud it stays None and the Application picks up Quix__Broker__*
+# from the platform.
 app = Application(
+    broker_address=os.getenv("KAFKA_BOOTSTRAP_SERVERS"),
     consumer_group=os.getenv("CONSUMER_GROUP", "s3_direct_sink_v1.0"),
     auto_offset_reset=os.getenv("AUTO_OFFSET_RESET", "latest"),
     commit_interval=_positive_int("COMMIT_INTERVAL", "30"),
@@ -83,14 +86,19 @@ workspace_id = os.getenv("Quix__Workspace__Id", "")
 # Note: Blob storage credentials are configured via Quix__BlobStorage__Connection__Json
 # environment variable, which is automatically read by quixportal.
 # The bucket name is extracted automatically from the quixportal configuration.
+# Quix Portal injects the Catalog URL under both the Quix naming convention
+# (`Quix__Lakehouse__Catalog__Url`) and the PyIceberg one (`CATALOG_URL`) when a Lakehouse Catalog
+# deployment exists in the workspace; prefer the Quix name, fall back to the PyIceberg one for
+# legacy compatibility. Same for the auth token. No Sdk-token fallback — the platform always
+# injects the catalog token when a catalog is bound.
 blob_sink = QuixTSDataLakeSink(
     s3_prefix=TIMESERIES_PREFIX,
     table_name=table_name,
     workspace_id=workspace_id,
     hive_columns=hive_columns,
     timestamp_column=os.getenv("TIMESTAMP_COLUMN", "ts_ms"),
-    catalog_url=os.getenv("CATALOG_URL"),
-    catalog_auth_token=os.getenv("CATALOG_AUTH_TOKEN", os.getenv("Quix__Sdk__Token", "")),
+    catalog_url=os.getenv("Quix__Lakehouse__Catalog__Url") or os.getenv("CATALOG_URL"),
+    catalog_auth_token=os.getenv("Quix__Lakehouse__Catalog__AuthToken") or os.getenv("CATALOG_AUTH_TOKEN"),
     auto_discover=auto_discover,
     namespace=os.getenv("CATALOG_NAMESPACE", "default"),
     auto_create_bucket=True,

--- a/python/destinations/quixlake-timeseries/main.py
+++ b/python/destinations/quixlake-timeseries/main.py
@@ -89,8 +89,8 @@ workspace_id = os.getenv("Quix__Workspace__Id", "")
 # Quix Portal injects the Catalog URL under both the Quix naming convention
 # (`Quix__Lakehouse__Catalog__Url`) and the PyIceberg one (`CATALOG_URL`) when a Lakehouse Catalog
 # deployment exists in the workspace; prefer the Quix name, fall back to the PyIceberg one for
-# legacy compatibility. Same for the auth token. No Sdk-token fallback — the platform always
-# injects the catalog token when a catalog is bound.
+# legacy compatibility. The auth token is only injected under the Quix name — it routes via the
+# secrets-bag / secretKeyRef path that the platform uses for the Catalog's own credentials.
 blob_sink = QuixTSDataLakeSink(
     s3_prefix=TIMESERIES_PREFIX,
     table_name=table_name,
@@ -98,7 +98,7 @@ blob_sink = QuixTSDataLakeSink(
     hive_columns=hive_columns,
     timestamp_column=os.getenv("TIMESTAMP_COLUMN", "ts_ms"),
     catalog_url=os.getenv("Quix__Lakehouse__Catalog__Url") or os.getenv("CATALOG_URL"),
-    catalog_auth_token=os.getenv("Quix__Lakehouse__Catalog__AuthToken") or os.getenv("CATALOG_AUTH_TOKEN"),
+    catalog_auth_token=os.getenv("Quix__Lakehouse__Catalog__AuthToken"),
     auto_discover=auto_discover,
     namespace=os.getenv("CATALOG_NAMESPACE", "default"),
     auto_create_bucket=True,

--- a/python/others/marimo/library.json
+++ b/python/others/marimo/library.json
@@ -32,6 +32,9 @@
         }
       ]
     },
+    "blobStorage": {
+      "bind": true
+    },
     "plugin": {
       "embeddedView": {
         "enabled": true,

--- a/python/others/marimo/main.py
+++ b/python/others/marimo/main.py
@@ -30,12 +30,9 @@ def _(mo):
 
 @app.cell
 def _(QuixLakeClient, os):
-    # TODO: Replace with your QuixLake URL
-    QUIXLAKE_URL = "https://your-quixlake-instance.quix.io"
-
     client = QuixLakeClient(
-        base_url=QUIXLAKE_URL,
-        token=os.environ["Quix__Sdk__Token"]
+        base_url=os.environ["Quix__Lakehouse__Query__Url"],
+        token=os.environ["Quix__Sdk__Token"],
     )
     return (client,)
 


### PR DESCRIPTION
## Summary
Reads `base_url` from `Quix__Lakehouse__Query__Url` instead of the hardcoded `https://your-quixlake-instance.quix.io` placeholder, so the notebook works out of the box on any workspace where the v2 lake is provisioned. Token continues to use `Quix__Sdk__Token`.

## Gate
`Quix__Lakehouse__Query__Url` is injected by `Quix.Portal.Backend` once [PR 10252 / `feature/lakehouse`] merges to master. Until then, this sample raises `KeyError` in a marimo devsession built from a pre-merge image. Land this after that PR.

## Ticket
[sc-72287](https://app.shortcut.com/quix/story/72287)

## Test plan
- [ ] Build the marimo devsession image and confirm `Quix__Lakehouse__Query__Url` arrives in the container after `feature/lakehouse` merges
- [ ] Open the marimo notebook in a devsession against a workspace with v2 lake provisioned, run the default query