### PR TITLE
Bump `quixstreams` to 3.23.7 and align Python sample requirements

### DIFF
--- a/python/destinations/MQTT/requirements.txt
+++ b/python/destinations/MQTT/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 paho-mqtt==2.1.0
 python-dotenv

--- a/python/destinations/TDengine/requirements.txt
+++ b/python/destinations/TDengine/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[tdengine]==3.23.6
+﻿quixstreams[tdengine]==3.23.7
 python-dotenv

--- a/python/destinations/big_query/requirements.txt
+++ b/python/destinations/big_query/requirements.txt
@@ -1,4 +1,3 @@
-﻿--extra-index-url https://pkgs.dev.azure.com/quix-analytics/53f7fe95-59fe-4307-b479-2473b96de6d1/_packaging/public/pypi/simple/
-quixstreams==3.23.7
+﻿quixstreams==3.23.7
 google-cloud-bigquery
 python-dotenv

--- a/python/destinations/big_query/requirements.txt
+++ b/python/destinations/big_query/requirements.txt
@@ -1,4 +1,4 @@
---extra-index-url https://pkgs.dev.azure.com/quix-analytics/53f7fe95-59fe-4307-b479-2473b96de6d1/_packaging/public/pypi/simple/
-quixstreams==3.23.6
+﻿--extra-index-url https://pkgs.dev.azure.com/quix-analytics/53f7fe95-59fe-4307-b479-2473b96de6d1/_packaging/public/pypi/simple/
+quixstreams==3.23.7
 google-cloud-bigquery
 python-dotenv

--- a/python/destinations/confluent_kafka/requirements.txt
+++ b/python/destinations/confluent_kafka/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/destinations/elasticsearch/requirements.txt
+++ b/python/destinations/elasticsearch/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[elasticsearch]==3.23.6
+﻿quixstreams[elasticsearch]==3.23.7
 python-dotenv

--- a/python/destinations/flet-waveform/requirements.txt
+++ b/python/destinations/flet-waveform/requirements.txt
@@ -1,3 +1,3 @@
-flet
-quixstreams==3.23.6
+﻿flet
+quixstreams==3.23.7
 python-dotenv

--- a/python/destinations/hivemq/requirements.txt
+++ b/python/destinations/hivemq/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 paho-mqtt==2.1.0
 python-dotenv

--- a/python/destinations/influxdb_1/requirements.txt
+++ b/python/destinations/influxdb_1/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[influxdb1]==3.23.6
+﻿quixstreams[influxdb1]==3.23.7
 python-dotenv

--- a/python/destinations/influxdb_3/requirements.txt
+++ b/python/destinations/influxdb_3/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams[influxdb3]==3.23.6
+﻿quixstreams[influxdb3]==3.23.7
 influxdb3-python
 python-dotenv

--- a/python/destinations/mongodb/requirements.txt
+++ b/python/destinations/mongodb/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[mongodb]==3.23.6
+﻿quixstreams[mongodb]==3.23.7
 python-dotenv

--- a/python/destinations/postgres/requirements.txt
+++ b/python/destinations/postgres/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[postgresql]==3.23.6
+﻿quixstreams[postgresql]==3.23.7
 python-dotenv

--- a/python/destinations/quixlake-timeseries/requirements.txt
+++ b/python/destinations/quixlake-timeseries/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams[quixdatalake]>=3.23.6
+﻿quixstreams[quixdatalake]>=3.23.7
 python-dotenv
 
 # Blob storage support via quixportal (AWS S3, Azure, GCP, MinIO)

--- a/python/destinations/redis_dest/requirements.txt
+++ b/python/destinations/redis_dest/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 redis
 python-dotenv

--- a/python/destinations/s3-file/requirements.txt
+++ b/python/destinations/s3-file/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv
 requests
 pandas

--- a/python/destinations/s3-iceberg-destination/requirements.txt
+++ b/python/destinations/s3-iceberg-destination/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[iceberg_aws]==3.23.6
+﻿quixstreams[iceberg_aws]==3.23.7
 python-dotenv

--- a/python/destinations/slack_notifications/requirements.txt
+++ b/python/destinations/slack_notifications/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 requests
 python-dotenv

--- a/python/destinations/starter_destination/requirements.txt
+++ b/python/destinations/starter_destination/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/destinations/websocket/requirements.txt
+++ b/python/destinations/websocket/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv
 websockets>=14.0
 asyncio

--- a/python/others/jupyterlab/requirements.txt
+++ b/python/others/jupyterlab/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv
 jupyterlab
 notebook

--- a/python/sources/MQTT/requirements.txt
+++ b/python/sources/MQTT/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[mqtt]==3.23.6
+﻿quixstreams[mqtt]==3.23.7
 python-dotenv

--- a/python/sources/confluent_kafka/requirements.txt
+++ b/python/sources/confluent_kafka/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/sources/demo_data/requirements.txt
+++ b/python/sources/demo_data/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[pandas]==3.23.6
+﻿quixstreams[pandas]==3.23.7
 python-dotenv

--- a/python/sources/environment_source/requirements.txt
+++ b/python/sources/environment_source/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/sources/flet-input-form/requirements.txt
+++ b/python/sources/flet-input-form/requirements.txt
@@ -1,3 +1,3 @@
-flet
-quixstreams==3.23.6
+﻿flet
+quixstreams==3.23.7
 python-dotenv

--- a/python/sources/hivemq/requirements.txt
+++ b/python/sources/hivemq/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams[mqtt]==3.23.6
+﻿quixstreams[mqtt]==3.23.7
 python-dotenv

--- a/python/sources/http_api_source/requirements.txt
+++ b/python/sources/http_api_source/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 flask
 flask_cors
 flasgger==0.9.7b2

--- a/python/sources/influxdb_2/requirements.txt
+++ b/python/sources/influxdb_2/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 influxdb-client==1.39.0
 pandas
 python-dotenv

--- a/python/sources/influxdb_3/requirements.txt
+++ b/python/sources/influxdb_3/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 influxdb3-python==0.3.6
 python-dotenv

--- a/python/sources/kafka/requirements.txt
+++ b/python/sources/kafka/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/sources/opc_ua_client/requirements.txt
+++ b/python/sources/opc_ua_client/requirements.txt
@@ -1,2 +1,2 @@
-asyncua
-quixstreams==3.23.6
+﻿asyncua
+quixstreams==3.23.7

--- a/python/sources/postgres_cdc/requirements.txt
+++ b/python/sources/postgres_cdc/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 psycopg2-binary
 python-dotenv

--- a/python/sources/redis_source/requirements.txt
+++ b/python/sources/redis_source/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 pandas
 redis
 python-dotenv

--- a/python/sources/s3_source/requirements.txt
+++ b/python/sources/s3_source/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv
 boto3

--- a/python/sources/segment_webhook/requirements.txt
+++ b/python/sources/segment_webhook/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 flask
 requests
 waitress

--- a/python/sources/snowplow_source/requirements.txt
+++ b/python/sources/snowplow_source/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 boto3
 snowplow_analytics_sdk
 python-dotenv

--- a/python/sources/sql_cdc/requirements.txt
+++ b/python/sources/sql_cdc/requirements.txt
@@ -1,3 +1,3 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 pyodbc==5.2.0
 python-dotenv==1.1.1

--- a/python/sources/starter_source/requirements.txt
+++ b/python/sources/starter_source/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/transformations/event_detection/requirements.txt
+++ b/python/transformations/event_detection/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/transformations/fmu-runner/requirements.txt
+++ b/python/transformations/fmu-runner/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 fmpy>=0.3.0
 numpy
 pandas

--- a/python/transformations/hugging_face_model/requirements.txt
+++ b/python/transformations/hugging_face_model/requirements.txt
@@ -1,4 +1,4 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 transformers
 tensorflow
 python-dotenv

--- a/python/transformations/quix_configuration_enricher/requirements.txt
+++ b/python/transformations/quix_configuration_enricher/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/transformations/starter_transformation/requirements.txt
+++ b/python/transformations/starter_transformation/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/python/transformations/transformation-with-tests/requirements.txt
+++ b/python/transformations/transformation-with-tests/requirements.txt
@@ -1,2 +1,2 @@
-quixstreams==3.23.6
+﻿quixstreams==3.23.7
 python-dotenv

--- a/tests/framework/requirements.txt
+++ b/tests/framework/requirements.txt
@@ -1,6 +1,6 @@
-pytest==7.4.3
+﻿pytest==7.4.3
 pytest-forked==1.6.0
 pytest-json-report==1.5.0
 pytest-html==4.1.1
 pytest-timeout==2.2.0
-quixstreams>=3.23.6
+quixstreams>=3.23.7


### PR DESCRIPTION
- Update `quixstreams` dependency to `3.23.7` across all Python samples.
- Correctly assign `quixstreams` extras (e.g., `[mongodb]`, `[mqtt]`) by renaming and updating `requirements.txt` files to match their corresponding sample directories.