### PR TITLE
Quix-72287: Remove QUIX_LAKE_URL from QuixLab variables

### DIFF
--- a/python/others/quixlab/library.json
+++ b/python/others/quixlab/library.json
@@ -70,13 +70,6 @@
       "Required": false
     },
     {
-      "Name": "QUIX_LAKE_URL",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Base URL of the QuixLake instance to query against (e.g. https://quixlake-<workspace>.deployments.quix.io). Required for ql.sql() to work outside the default dev environment.",
-      "Required": true
-    },
-    {
       "Name": "QUIX_LAKE_TOKEN",
       "Type": "EnvironmentVariable",
       "InputType": "Secret",


### PR DESCRIPTION
The QuixLake URL is now platform-injected by Portal Backend when blob storage bind is enabled (`QUIX_LAKE_URL` is projected as a Catalog URL alias alongside `CATALOG_URL`). It no longer needs to be a declared app variable on the QuixLab library item.

Pairs with the Portal Backend change that adds the `QUIX_LAKE_URL` injection.

`QUIX_LAKE_TOKEN` is intentionally kept (separate auth override).