### PR TITLE
Quix-73364: add Variables Demo sample (project variables + variable groups)

### DIFF
--- a/python/sources/variables-demo/README.md
+++ b/python/sources/variables-demo/README.md
@@ -1,0 +1,55 @@
+# Variables Demo
+
+[This code sample](https://github.com/quixio/quix-samples/tree/main/python/sources/variables-demo) demonstrates the Quix variable system end-to-end. A single library item declares three resolution mechanisms; on deployment the backend resolves each one into environment variables before the container starts, and the container logs the resolved values (the secret masked) plus emits one heartbeat to the output topic so resolution can be verified from the deployment logs.
+
+## The three mechanisms
+
+- **`InputType: ProjectVariable` (non-secret)** — `API_REGION` references a Project Variable. The `DefaultValue` (`demo_api_region`) is the *key* of the project variable to resolve, not a literal value. The backend resolves it to the variable's value before the container starts.
+- **`InputType: ProjectVariable` with `"Secret": true`** — `API_SECRET` references a *secret* Project Variable (`demo_api_secret`). It is resolved from a Kubernetes secret and injected the same way as `API_REGION`, but is masked in the logs. The committed `library.json` never holds a real secret value — only the key to resolve.
+- **`InputType: VariableGroup`** — `INFLUXDB_CONNECTION` references a shared Variable Group by its `VariableGroupId` (`influxdb-connection`). At deployment the selected value set is bulk-expanded into the individual environment variables declared under `Variables[]` (`INFLUXDB_HOST`, `INFLUXDB_PORT`, `INFLUXDB_ORG`) — all non-secret here.
+
+## How to run
+
+Create a [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) account or log-in and visit the Samples to use this project.
+
+Clicking `Deploy` on the Sample, deploys a pre-built container in Quix. Complete the environment variables to configure the container.
+
+Clicking `Edit code` on the Sample, forks the project to your own Git repo so you can customize it before deploying.
+
+## Prerequisites in the workspace
+
+Before deploying, create the references this sample resolves:
+
+1. A **Project Variable** named `demo_api_region` with any non-empty value (non-secret).
+2. A **secret Project Variable** named `demo_api_secret` with any non-empty value (mark it as secret so it is stored and delivered as a Kubernetes secret).
+3. A **Variable Group** named `influxdb-connection` with at least one value set whose keys are `INFLUXDB_HOST`, `INFLUXDB_PORT`, and `INFLUXDB_ORG`. Make sure it is linked to the project (or environment) you are deploying into.
+
+## Environment variables
+
+The code sample uses the following environment variables:
+
+- **output**: Output topic to write the heartbeat message into.
+- **LOG_LEVEL**: Logging level for the container (optional, defaults to `INFO`).
+- **API_REGION**: Reference to the non-secret Project Variable `demo_api_region`.
+- **API_SECRET**: Reference to the secret Project Variable `demo_api_secret` (masked in logs).
+- **INFLUXDB_HOST**, **INFLUXDB_PORT**, **INFLUXDB_ORG**: Injected from the `influxdb-connection` Variable Group.
+
+## Verifying resolution
+
+After deployment, open the container logs and look for the line:
+
+```
+Resolved variables from backend: {"API_REGION": "...", "API_SECRET": "ab***yz", "INFLUXDB_HOST": "...", "INFLUXDB_PORT": "...", "INFLUXDB_ORG": "..."}
+```
+
+`API_SECRET` is masked; every other value should show the resolved value. A `Missing required variables...` warning means a prerequisite above was not created or not linked. A `Published heartbeat to topic '<output>'` line confirms the single heartbeat reached the output topic.
+
+## Contribute
+
+Submit forked projects to the Quix [GitHub](https://github.com/quixio/quix-samples) repo. Any new project that we accept will be attributed to you and you'll receive $200 in Quix credit.
+
+## Open source
+
+This project is open source under the Apache 2.0 license and available in our [GitHub](https://github.com/quixio/quix-samples) repo.
+
+Please star us and mention us on social to show your appreciation.

--- a/python/sources/variables-demo/README.md
+++ b/python/sources/variables-demo/README.md
@@ -1,11 +1,11 @@
 # Variables Demo
 
-[This code sample](https://github.com/quixio/quix-samples/tree/main/python/sources/variables-demo) demonstrates the Quix variable system end-to-end. A single library item declares three resolution mechanisms; on deployment the backend resolves each one into environment variables before the container starts, and the container logs the resolved values (the secret masked) plus emits one heartbeat to the output topic so resolution can be verified from the deployment logs.
+[This code sample](https://github.com/quixio/quix-samples/tree/main/python/sources/variables-demo) demonstrates the Quix variable system end-to-end. A single library item declares three resolution mechanisms; on deployment the backend resolves each one into environment variables before the container starts, and the container logs the resolved values (the secret partially masked) plus emits periodic heartbeats to the output topic so resolution can be verified from the deployment logs.
 
 ## The three mechanisms
 
 - **`InputType: ProjectVariable` (non-secret)** — `API_REGION` references a Project Variable. The `DefaultValue` (`demo_api_region`) is the *key* of the project variable to resolve, not a literal value. The backend resolves it to the variable's value before the container starts.
-- **`InputType: ProjectVariable` with `"Secret": true`** — `API_SECRET` references a *secret* Project Variable (`demo_api_secret`). It is resolved from a Kubernetes secret and injected the same way as `API_REGION`, but is masked in the logs. The committed `library.json` never holds a real secret value — only the key to resolve.
+- **`InputType: ProjectVariable` with `"Secret": true`** — `API_SECRET` references a *secret* Project Variable (`demo_api_secret`). It is resolved from a Kubernetes secret and injected the same way as `API_REGION`, but is **partially masked** in the logs (first and last couple of characters shown) so you can confirm it resolved to the expected value without exposing the whole secret. The committed `library.json` never holds a real secret value — only the key to resolve.
 - **`InputType: VariableGroup`** — `INFLUXDB_CONNECTION` references a shared Variable Group by its `VariableGroupId` (`influxdb-connection`). At deployment the selected value set is bulk-expanded into the individual environment variables declared under `Variables[]` (`INFLUXDB_HOST`, `INFLUXDB_PORT`, `INFLUXDB_ORG`) — all non-secret here.
 
 ## How to run
@@ -28,10 +28,12 @@ Before deploying, create the references this sample resolves:
 
 The code sample uses the following environment variables:
 
-- **output**: Output topic to write the heartbeat message into.
+- **output**: Output topic to write the heartbeat messages into.
 - **LOG_LEVEL**: Logging level for the container (optional, defaults to `INFO`).
+- **HEARTBEAT_INTERVAL_SECONDS**: Seconds between heartbeats (optional, defaults to `5`).
+- **HEARTBEAT_COUNT**: Number of heartbeats to emit before the job completes (optional, defaults to `12`).
 - **API_REGION**: Reference to the non-secret Project Variable `demo_api_region`.
-- **API_SECRET**: Reference to the secret Project Variable `demo_api_secret` (masked in logs).
+- **API_SECRET**: Reference to the secret Project Variable `demo_api_secret` (partially masked in logs).
 - **INFLUXDB_HOST**, **INFLUXDB_PORT**, **INFLUXDB_ORG**: Injected from the `influxdb-connection` Variable Group.
 
 ## Verifying resolution
@@ -39,10 +41,10 @@ The code sample uses the following environment variables:
 After deployment, open the container logs and look for the line:
 
 ```
-Resolved variables from backend: {"API_REGION": "...", "API_SECRET": "***", "INFLUXDB_HOST": "...", "INFLUXDB_PORT": "...", "INFLUXDB_ORG": "..."}
+Resolved variables from backend: {"API_REGION": "...", "API_SECRET": "se***et", "INFLUXDB_HOST": "...", "INFLUXDB_PORT": "...", "INFLUXDB_ORG": "..."}
 ```
 
-`API_SECRET` is masked; every other value should show the resolved value. A `Missing required variables...` warning means a prerequisite above was not created or not linked. A `Published heartbeat to topic '<output>'` line confirms the single heartbeat reached the output topic.
+`API_SECRET` is partially masked (first/last couple of chars) so you can confirm it resolved to the expected value; every other value shows in full. A `Missing required variables...` warning means a prerequisite above was not created or not linked. The job then emits `HEARTBEAT_COUNT` heartbeats — look for `Published heartbeat N/M to topic '<output>'` lines, then a final `Variables demo complete` once it finishes.
 
 ## Contribute
 

--- a/python/sources/variables-demo/README.md
+++ b/python/sources/variables-demo/README.md
@@ -39,7 +39,7 @@ The code sample uses the following environment variables:
 After deployment, open the container logs and look for the line:
 
 ```
-Resolved variables from backend: {"API_REGION": "...", "API_SECRET": "ab***yz", "INFLUXDB_HOST": "...", "INFLUXDB_PORT": "...", "INFLUXDB_ORG": "..."}
+Resolved variables from backend: {"API_REGION": "...", "API_SECRET": "***", "INFLUXDB_HOST": "...", "INFLUXDB_PORT": "...", "INFLUXDB_ORG": "..."}
 ```
 
 `API_SECRET` is masked; every other value should show the resolved value. A `Missing required variables...` warning means a prerequisite above was not created or not linked. A `Published heartbeat to topic '<output>'` line confirms the single heartbeat reached the output topic.

--- a/python/sources/variables-demo/dockerfile
+++ b/python/sources/variables-demo/dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim-bookworm
+
+# Set environment variables for non-interactive setup and unbuffered output
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    PYTHONPATH="/app"
+
+# Build argument for setting the main app path
+ARG MAINAPPPATH=.
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy requirements to leverage Docker cache
+COPY "${MAINAPPPATH}/requirements.txt" "${MAINAPPPATH}/requirements.txt"
+
+# Install dependencies without caching
+RUN pip install --no-cache-dir -r "${MAINAPPPATH}/requirements.txt"
+
+# Copy entire application into container
+COPY . .
+
+# Set working directory to main app path
+WORKDIR "/app/${MAINAPPPATH}"
+
+# Define the container's startup command
+ENTRYPOINT ["python3", "main.py"]

--- a/python/sources/variables-demo/library.json
+++ b/python/sources/variables-demo/library.json
@@ -28,7 +28,7 @@
       "Name": "output",
       "Type": "EnvironmentVariable",
       "InputType": "OutputTopic",
-      "Description": "Output topic to write a heartbeat message into.",
+      "Description": "Output topic to write the heartbeat messages into.",
       "DefaultValue": "variables-demo-out",
       "Required": true
     },
@@ -38,6 +38,22 @@
       "InputType": "FreeText",
       "Description": "Logging level for the demo container.",
       "DefaultValue": "INFO",
+      "Required": false
+    },
+    {
+      "Name": "HEARTBEAT_INTERVAL_SECONDS",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "Seconds between heartbeat messages (demo runtime knob).",
+      "DefaultValue": "5",
+      "Required": false
+    },
+    {
+      "Name": "HEARTBEAT_COUNT",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "How many heartbeats to emit before the job completes (demo runtime knob).",
+      "DefaultValue": "12",
       "Required": false
     },
     {

--- a/python/sources/variables-demo/library.json
+++ b/python/sources/variables-demo/library.json
@@ -61,10 +61,10 @@
     {
       "Name": "INFLUXDB_CONNECTION",
       "InputType": "VariableGroup",
-      "Description": "InfluxDB connection details from a shared Variable Group. The selected value set's keys are injected as individual environment variables at runtime.",
+      "Description": "InfluxDB connection details, injected from a shared Variable Group's selected value set.",
       "VariableGroupId": "influxdb-connection",
       "VariableGroupName": "InfluxDB Connection",
-      "VariableGroupDescription": "Shared, non-secret InfluxDB connection details (host, port, organization).",
+      "VariableGroupDescription": "InfluxDB connection details (host, port, organization).",
       "Required": true,
       "Variables": [
         {

--- a/python/sources/variables-demo/library.json
+++ b/python/sources/variables-demo/library.json
@@ -1,0 +1,102 @@
+{
+  "libraryItemId": "variables-demo",
+  "name": "Variables Demo",
+  "language": "Python",
+  "IsHighlighted": false,
+  "DisplayOrder": 99,
+  "tags": {
+    "Pipeline Stage": [
+      "Source"
+    ],
+    "Type": [
+      "Demos"
+    ],
+    "Complexity": [
+      "Easy"
+    ],
+    "Technology": [
+      "Quix Streams"
+    ]
+  },
+  "shortDescription": "Demonstrates project variables (secret and non-secret) and variable groups end-to-end.",
+  "longDescription": "Reference example for the Quix variable system. A single library item declares three resolution mechanisms: a plain Project Variable (API_REGION), a secret Project Variable (API_SECRET, delivered as a Kubernetes secret), and a Variable Group (INFLUXDB_CONNECTION) whose selected value set is bulk-expanded into individual environment variables. On deployment the backend resolves each reference before the container starts; the container then logs every resolved value (the secret masked) and emits one heartbeat message to the output topic, so the runtime injection can be verified directly from the deployment logs.",
+  "DefaultFile": "main.py",
+  "EntryPoint": "dockerfile",
+  "RunEntryPoint": "main.py",
+  "Variables": [
+    {
+      "Name": "output",
+      "Type": "EnvironmentVariable",
+      "InputType": "OutputTopic",
+      "Description": "Output topic to write a heartbeat message into.",
+      "DefaultValue": "variables-demo-out",
+      "Required": true
+    },
+    {
+      "Name": "LOG_LEVEL",
+      "Type": "EnvironmentVariable",
+      "InputType": "FreeText",
+      "Description": "Logging level for the demo container.",
+      "DefaultValue": "INFO",
+      "Required": false
+    },
+    {
+      "Name": "API_REGION",
+      "Type": "EnvironmentVariable",
+      "InputType": "ProjectVariable",
+      "Description": "Reference to a non-secret Project Variable holding a non-sensitive config value (e.g. an API region). The DefaultValue is the project-variable key to resolve, not a literal value.",
+      "DefaultValue": "demo_api_region",
+      "Required": true,
+      "Secret": false
+    },
+    {
+      "Name": "API_SECRET",
+      "Type": "EnvironmentVariable",
+      "InputType": "ProjectVariable",
+      "Description": "Reference to a secret Project Variable holding an API secret. Resolved from a Kubernetes secret; the DefaultValue is the project-variable key to resolve, never a real secret value.",
+      "DefaultValue": "demo_api_secret",
+      "Required": true,
+      "Secret": true
+    },
+    {
+      "Name": "INFLUXDB_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "InfluxDB connection details from a shared Variable Group. The selected value set's keys are injected as individual environment variables at runtime.",
+      "VariableGroupId": "influxdb-connection",
+      "VariableGroupName": "InfluxDB Connection",
+      "VariableGroupDescription": "Shared, non-secret InfluxDB connection details (host, port, organization).",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "INFLUXDB_HOST",
+          "Description": "InfluxDB hostname.",
+          "DefaultValue": "localhost",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB_PORT",
+          "Description": "InfluxDB port.",
+          "DefaultValue": "8086",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB_ORG",
+          "Description": "InfluxDB organization.",
+          "DefaultValue": "my-org",
+          "Secret": false,
+          "Required": true
+        }
+      ]
+    }
+  ],
+  "DeploySettings": {
+    "DeploymentType": "Job",
+    "CpuMillicores": 200,
+    "MemoryInMb": 200,
+    "Replicas": 1,
+    "PublicAccess": false,
+    "ValidateConnection": false
+  }
+}

--- a/python/sources/variables-demo/main.py
+++ b/python/sources/variables-demo/main.py
@@ -20,8 +20,13 @@ log = logging.getLogger("variables-demo")
 
 
 def mask(value: str) -> str:
-    """Fully mask a secret value for logging: reveal whether it resolved, never its contents."""
-    return "<empty>" if not value else "***"
+    """Partially mask a secret for logging: reveal the first and last couple of chars so the
+    *expected* value can be confirmed, without ever printing the whole secret."""
+    if not value:
+        return "<empty>"
+    if len(value) <= 4:
+        return value[0] + "***"
+    return f"{value[:2]}***{value[-2:]}"
 
 
 # --- Project Variables ---------------------------------------------------------
@@ -65,22 +70,33 @@ topic_name = os.getenv("output")
 if not topic_name:
     raise ValueError("The 'output' environment variable is required.")
 
-# Emit a single heartbeat so successful resolution is visible on the output topic too.
+# Keep resolution observable for a while instead of exiting after one message: emit a
+# heartbeat every HEARTBEAT_INTERVAL_SECONDS until HEARTBEAT_COUNT have been sent, then
+# finish cleanly. Both are configurable (default: a beat every 5s, 12 times = ~1 minute).
+heartbeat_interval = float(os.getenv("HEARTBEAT_INTERVAL_SECONDS", "5"))
+heartbeat_count = int(os.getenv("HEARTBEAT_COUNT", "12"))
+
 app = Application(consumer_group="variables-demo", auto_create_topics=True)
 output_topic = app.topic(topic_name)
 
 with app.get_producer() as producer:
-    payload = {
-        "ts": int(time.time() * 1000),
-        "api_region": api_region,
-        "api_secret_masked": api_secret_masked,
-        "influxdb_host": influx_host,
-        "influxdb_port": influx_port,
-        "influxdb_org": influx_org,
-    }
-    producer.produce(
-        topic=output_topic.name,
-        key="variables-demo",
-        value=json.dumps(payload).encode("utf-8"),
-    )
-    log.info("Published heartbeat to topic '%s'", topic_name)
+    for beat in range(1, heartbeat_count + 1):
+        payload = {
+            "ts": int(time.time() * 1000),
+            "heartbeat": beat,
+            "api_region": api_region,
+            "api_secret_masked": api_secret_masked,
+            "influxdb_host": influx_host,
+            "influxdb_port": influx_port,
+            "influxdb_org": influx_org,
+        }
+        producer.produce(
+            topic=output_topic.name,
+            key="variables-demo",
+            value=json.dumps(payload).encode("utf-8"),
+        )
+        log.info("Published heartbeat %d/%d to topic '%s'", beat, heartbeat_count, topic_name)
+        if beat < heartbeat_count:
+            time.sleep(heartbeat_interval)
+
+log.info("Variables demo complete - emitted %d heartbeats.", heartbeat_count)

--- a/python/sources/variables-demo/main.py
+++ b/python/sources/variables-demo/main.py
@@ -20,12 +20,8 @@ log = logging.getLogger("variables-demo")
 
 
 def mask(value: str) -> str:
-    """Mask a secret value for logging, keeping just enough to spot-check it resolved."""
-    if not value:
-        return "<empty>"
-    if len(value) <= 4:
-        return "***"
-    return f"{value[:2]}***{value[-2:]}"
+    """Fully mask a secret value for logging: reveal whether it resolved, never its contents."""
+    return "<empty>" if not value else "***"
 
 
 # --- Project Variables ---------------------------------------------------------

--- a/python/sources/variables-demo/main.py
+++ b/python/sources/variables-demo/main.py
@@ -1,0 +1,90 @@
+import json
+import logging
+import os
+import time
+
+# For local dev, load env vars from a .env file (does not override real env vars).
+from dotenv import load_dotenv
+from quixstreams import Application
+
+load_dotenv(override=False)
+
+# Resolve the log level defensively: an unrecognized LOG_LEVEL (e.g. a typo) must
+# not crash the container at startup, so fall back to INFO.
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("variables-demo")
+
+
+def mask(value: str) -> str:
+    """Mask a secret value for logging, keeping just enough to spot-check it resolved."""
+    if not value:
+        return "<empty>"
+    if len(value) <= 4:
+        return "***"
+    return f"{value[:2]}***{value[-2:]}"
+
+
+# --- Project Variables ---------------------------------------------------------
+# A ProjectVariable reference is resolved by the backend to the variable's value
+# before the container starts, so we read it as a normal environment variable.
+# API_REGION is non-secret; API_SECRET is delivered via a Kubernetes secret.
+api_region = os.getenv("API_REGION", "")
+api_secret = os.getenv("API_SECRET", "")
+
+# --- Variable Group ------------------------------------------------------------
+# The backend expands the selected value set of the group into individual env
+# vars matching the keys declared in library.json. All members here are non-secret.
+influx_host = os.getenv("INFLUXDB_HOST", "")
+influx_port = os.getenv("INFLUXDB_PORT", "")
+influx_org = os.getenv("INFLUXDB_ORG", "")
+
+# Read every resolved value once, then reuse it for both logging and the
+# missing-variable check so the two can never drift apart.
+api_secret_masked = mask(api_secret)
+values = {
+    "API_REGION": api_region,
+    "API_SECRET": api_secret,
+    "INFLUXDB_HOST": influx_host,
+    "INFLUXDB_PORT": influx_port,
+    "INFLUXDB_ORG": influx_org,
+}
+
+# Log every resolved value so injection can be verified from the deployment logs.
+# Only the secret project variable is masked.
+resolved = dict(values, API_SECRET=api_secret_masked)
+log.info("Resolved variables from backend: %s", json.dumps(resolved))
+
+# Warn on any required value that did not resolve (e.g. a missing prerequisite).
+missing = [k for k, v in values.items() if not v]
+if missing:
+    log.warning("Missing required variables after resolution: %s", missing)
+
+# 'output' is a hard deploy-time prerequisite (no topic means nothing to produce
+# to), unlike the resolved variables above which are observational and only warn.
+topic_name = os.getenv("output")
+if not topic_name:
+    raise ValueError("The 'output' environment variable is required.")
+
+# Emit a single heartbeat so successful resolution is visible on the output topic too.
+app = Application(consumer_group="variables-demo", auto_create_topics=True)
+output_topic = app.topic(topic_name)
+
+with app.get_producer() as producer:
+    payload = {
+        "ts": int(time.time() * 1000),
+        "api_region": api_region,
+        "api_secret_masked": api_secret_masked,
+        "influxdb_host": influx_host,
+        "influxdb_port": influx_port,
+        "influxdb_org": influx_org,
+    }
+    producer.produce(
+        topic=output_topic.name,
+        key="variables-demo",
+        value=json.dumps(payload).encode("utf-8"),
+    )
+    log.info("Published heartbeat to topic '%s'", topic_name)

--- a/python/sources/variables-demo/requirements.txt
+++ b/python/sources/variables-demo/requirements.txt
@@ -1,0 +1,2 @@
+quixstreams==3.24.0
+python-dotenv


### PR DESCRIPTION
Adds a source sample demonstrating the Quix variable system end-to-end: a plain Project Variable (API_REGION), a secret Project Variable (API_SECRET, Secret:true), and a Variable Group (INFLUXDB_CONNECTION). The backend resolves each reference before the container starts; the sample logs every resolved value with the secret fully masked and emits one heartbeat to the output topic so injection can be verified from the deployment logs. 