### PR TITLE
Pin QuixLab sample base image to v-stable

### DIFF
--- a/python/others/quixlab/dockerfile
+++ b/python/others/quixlab/dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/quixio/quixlab:main
+FROM ghcr.io/quixio/quixlab:v-stable


### PR DESCRIPTION
The `python/others/quixlab` sample dockerfile used the floating `ghcr.io/quixio/quixlab:main` tag, which drifts as main advances and can leave the sample building against an unstable QuixLab image. Pin it to the stable `v-stable` tag so the sample builds against a known-good QuixLab release.