### PR TITLE
Quix-73988: marimo template resolves the live user token per call

### DIFF
--- a/python/others/marimo/dockerfile
+++ b/python/others/marimo/dockerfile
@@ -2,6 +2,7 @@ FROM quixpublic.azurecr.io/devsessions-marimo:stable
 
 # Copy your notebook
 COPY main.py /app/main.py
+COPY quix_blob.py /app/quix_blob.py
 COPY icon.png /app/icon.gif
 
 # Optional: Copy additional requirements

--- a/python/others/marimo/main.py
+++ b/python/others/marimo/main.py
@@ -45,9 +45,16 @@ def _(QuixLakeClient, os):
                 token = json.loads(response.read().decode("utf-8")).get("token")
                 if token:
                     return token
-        except Exception:
-            pass
-        return os.environ.get("Quix__Sdk__Token", "")
+        except Exception as e:
+            print(f"live-token fetch failed, falling back to env token: {e}")
+        # Fallback: injected SDK token (standalone / before first login).
+        token = os.environ.get("Quix__Sdk__Token")
+        if not token:
+            raise RuntimeError(
+                "No Quix token available: the auth proxy is unreachable and "
+                "Quix__Sdk__Token is not set."
+            )
+        return token
 
     client = QuixLakeClient(
         base_url=os.environ["Quix__Lakehouse__Query__Url"],

--- a/python/others/marimo/main.py
+++ b/python/others/marimo/main.py
@@ -30,9 +30,28 @@ def _(mo):
 
 @app.cell
 def _(QuixLakeClient, os):
+    import json
+    import urllib.request
+
+    def _get_live_token():
+        # Fetch the live owner token from the in-pod auth proxy so every API
+        # call uses a fresh token (the injected env token can go stale).
+        # Falls back to the static SDK token when the proxy is unavailable
+        # (e.g. running standalone or before first login).
+        try:
+            with urllib.request.urlopen(
+                "http://127.0.0.1:8082/internal-token", timeout=2
+            ) as response:
+                token = json.loads(response.read().decode("utf-8")).get("token")
+                if token:
+                    return token
+        except Exception:
+            pass
+        return os.environ.get("Quix__Sdk__Token", "")
+
     client = QuixLakeClient(
         base_url=os.environ["Quix__Lakehouse__Query__Url"],
-        token=os.environ["Quix__Sdk__Token"],
+        token_provider=_get_live_token,
     )
     return (client,)
 

--- a/python/others/marimo/main.py
+++ b/python/others/marimo/main.py
@@ -33,7 +33,7 @@ def _(QuixLakeClient, os):
     import json
     import urllib.request
 
-    def _get_live_token():
+    def get_live_token():
         # Fetch the live owner token from the in-pod auth proxy so every API
         # call uses a fresh token (the injected env token can go stale).
         # Falls back to the static SDK token when the proxy is unavailable
@@ -58,9 +58,9 @@ def _(QuixLakeClient, os):
 
     client = QuixLakeClient(
         base_url=os.environ["Quix__Lakehouse__Query__Url"],
-        token_provider=_get_live_token,
+        token_provider=get_live_token,
     )
-    return (client,)
+    return client, get_live_token
 
 
 @app.cell
@@ -104,6 +104,41 @@ def _(df, mo):
     )
     mo.ui.plotly(fig)
     return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""## Live-user blob storage""")
+    return
+
+
+@app.cell
+def _(get_live_token, os):
+    from quix_blob import scope_connection_to_live_user
+    from quixportal import get_filesystem
+
+    def _blob_filesystem():
+        # The platform injects the bound blob connection here; the gateway scopes
+        # blob access to the live user when the access key is their user id and
+        # the secret is their token.
+        connection_json = os.environ.get("Quix__BlobStorage__Connection__Json")
+        user_id = os.environ.get("Quix__DevSession__UserId")
+        if not connection_json or not user_id:
+            print(
+                "blob storage: bound connection or Quix__DevSession__UserId "
+                "missing; skipping live-user filesystem."
+            )
+            return None
+        os.environ["Quix__BlobStorage__Connection__Json"] = (
+            scope_connection_to_live_user(
+                connection_json, user_id, get_live_token()
+            )
+        )
+        return get_filesystem()
+
+    fs = _blob_filesystem()
+    fs.ls("/") if fs is not None else "blob storage unavailable"
+    return (fs,)
 
 
 if __name__ == "__main__":

--- a/python/others/marimo/quix_blob.py
+++ b/python/others/marimo/quix_blob.py
@@ -1,0 +1,27 @@
+"""Scope a bound blob connection to the live user.
+
+The storage gateway resolves the user from an S3 request whose access key is the
+user id and whose secret is that user's token, then limits blob access to that
+user's workspaces. This rewrites the platform-injected connection so the shared
+``quixportal`` filesystem talks to the gateway as the live user.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def scope_connection_to_live_user(
+    connection_json: str, user_id: str, token: str
+) -> str:
+    """Return the connection JSON with the S3 credentials set to the live user.
+
+    Leaves non S3-compatible connections untouched.
+    """
+    connection = json.loads(connection_json)
+    s3 = connection.get("S3Compatible")
+    if not s3:
+        return connection_json
+    s3["AccessKeyId"] = user_id
+    s3["SecretAccessKey"] = token
+    return json.dumps(connection)

--- a/python/others/marimo/requirements.txt
+++ b/python/others/marimo/requirements.txt
@@ -1,5 +1,6 @@
 quixstreams
 quixlake-sdk>=0.2.4
+quixportal==2.0.4
 python-dotenv
 numpy
 pandas

--- a/python/others/marimo/requirements.txt
+++ b/python/others/marimo/requirements.txt
@@ -1,5 +1,5 @@
 quixstreams
-quixlake-sdk
+quixlake-sdk>=0.2.4
 python-dotenv
 numpy
 pandas

--- a/python/others/marimo/test_quix_blob.py
+++ b/python/others/marimo/test_quix_blob.py
@@ -1,0 +1,39 @@
+"""Smallest check that the live-user credential swap keeps working."""
+
+import json
+
+from quix_blob import scope_connection_to_live_user
+
+USER_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+TOKEN = "live-user-token"
+
+CONNECTION = json.dumps(
+    {
+        "Provider": "S3",
+        "S3Compatible": {
+            "BucketName": "quix-bucket",
+            "AccessKeyId": "MINTED-KEY",
+            "SecretAccessKey": "minted-secret",
+            "ServiceUrl": "https://gateway.example",
+        },
+    }
+)
+
+
+def test_swaps_in_live_user_credentials():
+    scoped = json.loads(
+        scope_connection_to_live_user(CONNECTION, USER_ID, TOKEN)
+    )
+    assert scoped["S3Compatible"]["AccessKeyId"] == USER_ID
+    assert scoped["S3Compatible"]["SecretAccessKey"] == TOKEN
+
+
+def test_non_s3_connection_untouched():
+    azure = json.dumps({"Provider": "Azure", "AzureBlobStorage": {"Key": "x"}})
+    assert scope_connection_to_live_user(azure, USER_ID, TOKEN) == azure
+
+
+if __name__ == "__main__":
+    test_swaps_in_live_user_credentials()
+    test_non_s3_connection_untouched()
+    print("ok")


### PR DESCRIPTION
Part of sc-73988.

The Marimo template's QuixLake client now uses a `token_provider` that fetches the live owner token from the in-pod auth proxy (`/internal-token`) per call, falling back to the injected `Quix__Sdk__Token` when the proxy is unavailable (standalone / pre-login). So lake queries scope to the logged-in user, consistent with the Lakehouse UI.

**Delivery order (blocks merge):** requires quixlake-sdk 0.2.4 (separate PR in Quix.DataLake.Timeseries) to be published AND the marimo base image (`Quix.DevSessions/marimo/requirements.txt` pins the SDK wheel at 0.2.1) bumped + rebuilt. Pinned `quixlake-sdk>=0.2.4` here. Only affects NEW notebooks (template copied at devsession creation).