### PR TITLE
Source connection config from Variable Groups across the sample library

### DIFF
--- a/docker/grafana/README.md
+++ b/docker/grafana/README.md
@@ -2,11 +2,26 @@
 
 This sample demonstrates how to deploy and use Grafana as a visualization tool in your Quix Cloud pipeline. Please note: this image is provided by Grafana and is offered as-is, with no specific support from Quix.
 
+## Configuration
+
+- **GF_SECURITY_ADMIN_PASSWORD** — password for the Grafana admin user, secret.
+
+The provisioned InfluxDB datasource takes its token from the shared
+**`influxdb2-config`** variable group, so Grafana, the bundled InfluxDB v2 server and the
+InfluxDB v2 Source all authenticate with the same token. Assign that group to this
+deployment (or your project/environment); the datasource reads **INFLUXDB2_TOKEN** from it.
+The legacy `INFLUXDB_TOKEN` variable still works for deployments created before the group
+was introduced.
+
+Note that `provisioning/datasources/influxdb.yaml` still hard-codes the datasource URL
+(`http://influxdb:80`), organization and database, which match the group defaults. Edit
+that file if your InfluxDB is elsewhere.
+
 ## How to Run
 
 1. Log in or sign up at [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) and navigate to the Code Samples section.
 2. Click **Deploy** to launch a pre-built container.
-3. Fill in the required environment variables for your Grafana instance.
+3. Set `GF_SECURITY_ADMIN_PASSWORD`, and assign the `influxdb2-config` variable group so the InfluxDB datasource gets its token.
 4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 ## Save dashboards with code

--- a/docker/grafana/README.md
+++ b/docker/grafana/README.md
@@ -10,8 +10,6 @@ The provisioned InfluxDB datasource takes its token from the shared
 **`influxdb2-config`** variable group, so Grafana, the bundled InfluxDB v2 server and the
 InfluxDB v2 Source all authenticate with the same token. Assign that group to this
 deployment (or your project/environment); the datasource reads **INFLUXDB2_TOKEN** from it.
-The legacy `INFLUXDB_TOKEN` variable still works for deployments created before the group
-was introduced.
 
 Note that `provisioning/datasources/influxdb.yaml` still hard-codes the datasource URL
 (`http://influxdb:80`), organization and database, which match the group defaults. Edit

--- a/docker/grafana/init.sh
+++ b/docker/grafana/init.sh
@@ -19,4 +19,9 @@ if [ ! -d "$TARGET_DIR" ]; then
   }
 fi
 
+# The InfluxDB datasource is provisioned with ${INFLUXDB2_TOKEN}, which comes from the
+# shared influxdb2-config Variable Group. Fall back to the legacy INFLUXDB_TOKEN name so
+# deployments created before the rename keep working.
+export INFLUXDB2_TOKEN="${INFLUXDB2_TOKEN:-$INFLUXDB_TOKEN}"
+
 exec su -s /bin/sh $TARGET_USER -c "/run.sh grafana-server --homepath=/usr/share/grafana"

--- a/docker/grafana/init.sh
+++ b/docker/grafana/init.sh
@@ -19,9 +19,4 @@ if [ ! -d "$TARGET_DIR" ]; then
   }
 fi
 
-# The InfluxDB datasource is provisioned with ${INFLUXDB2_TOKEN}, which comes from the
-# shared influxdb2-config Variable Group. Fall back to the legacy INFLUXDB_TOKEN name so
-# deployments created before the rename keep working.
-export INFLUXDB2_TOKEN="${INFLUXDB2_TOKEN:-$INFLUXDB_TOKEN}"
-
 exec su -s /bin/sh $TARGET_USER -c "/run.sh grafana-server --homepath=/usr/share/grafana"

--- a/docker/grafana/library.json
+++ b/docker/grafana/library.json
@@ -3,8 +3,12 @@
   "name": "Grafana",
   "language": "docker",
   "tags": {
-    "Category": ["Monitoring"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Monitoring"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run Grafana in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -19,8 +23,7 @@
     "UrlPrefix": "grafana",
     "Network": {
       "ServiceName": "grafana",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 80,
           "TargetPort": 3000
@@ -38,12 +41,57 @@
       "Required": true
     },
     {
-      "Name": "INFLUXDB_TOKEN",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The optional InfluxDB Token to use",
-      "DefaultValue": "INFLUXDB_ADMIN_TOKEN",
-      "Required": false
+      "Name": "INFLUXDB2_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "InfluxDB v2 connection details and admin token from a shared Variable Group.",
+      "VariableGroupId": "influxdb2-config",
+      "VariableGroupName": "InfluxDB v2 config",
+      "VariableGroupDescription": "Shared InfluxDB v2 connection details, admin token and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "INFLUXDB2_HOST",
+          "Description": "Base URL clients use to reach InfluxDB v2, including the http:// scheme and port",
+          "DefaultValue": "http://influxdb:80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_TOKEN",
+          "Description": "Admin token. Seeds server auth on first boot and authenticates clients",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_ORG",
+          "Description": "Organization the server is initialised with, and that clients query",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_BUCKET",
+          "Description": "Bucket the server is initialised with, and that clients read and write",
+          "DefaultValue": "demo",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_USERNAME",
+          "Description": "Admin username the server is initialised with",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_PASSWORD",
+          "Description": "Admin password the server is initialised with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
-  ]  
+  ]
 }

--- a/docker/grafana/provisioning/datasources/influxdb.yaml
+++ b/docker/grafana/provisioning/datasources/influxdb.yaml
@@ -16,6 +16,6 @@ datasources:
       organization: "quix"
       version: "Flux"
     secureJsonData:
-      token: "${INFLUXDB_TOKEN}"            
+      token: "${INFLUXDB2_TOKEN}"            
     version: 8
     readOnly: false

--- a/docker/influxdb1/README.md
+++ b/docker/influxdb1/README.md
@@ -2,16 +2,33 @@
 
 This sample demonstrates how to deploy and use InfluxDB v1 as a time series database in your Quix Cloud pipeline. Please note: this image is provided by Influx and is offered as-is, with no specific support from Quix. For any support, contact Influx directly.
 
+## Configuration
+
+This sample uses the shared **`influxdb1-config`** variable group, so the server and every
+client (source/sink) read the same connection details and credentials. Assign the group to
+this deployment (or your project/environment) with:
+
+- **INFLUXDB1_HOST** — host address clients use to reach the server, including the scheme (default `http://influxdb`)
+- **INFLUXDB1_PORT** — port clients connect on (default `80`, which maps to 8086 in the container)
+- **INFLUXDB1_DATABASE** — database the server is initialised with, and that clients read and write (default `quix`)
+- **INFLUXDB1_USERNAME** — admin username the server is initialised with (default `admin`)
+- **INFLUXDB1_PASSWORD** — admin password for that user, secret
+
+If a non-empty username and password are provided, HTTP API authentication is enabled. The
+v1 image reads `INFLUXDB_ADMIN_USER` / `INFLUXDB_ADMIN_PASSWORD` / `INFLUXDB_DB`; `init.sh`
+maps the group values onto those names, and falls back to them directly so deployments
+created before the group was introduced keep working.
+
 ## How to Run
 
 1. Create an account or log in to your [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) account and navigate to the Code Samples section.
 2. Click `Deploy` to launch a pre-built container in Quix.
-3. Configure authentication (username + password) for your InfluxDB instance:
-    - `INFLUXDB_ADMIN_USER`: Admin username
-    - `INFLUXDB_ADMIN_PASSWORD`: Admin password
+3. Assign the `influxdb1-config` variable group and set authentication (username + password) for your InfluxDB instance:
+    - `INFLUXDB1_USERNAME`: Admin username
+    - `INFLUXDB1_PASSWORD`: Admin password
     > Note: If non-empty username + password are provided, HTTP API authentication is also enabled
-4. **\[Recommended, Optional\]** configure your DB name with the environment variable:   
-    - `INFLUXDB_DB`: Database name to create (else, defaults to: `quix`)
+4. **\[Recommended, Optional\]** configure your DB name in the same group:   
+    - `INFLUXDB1_DATABASE`: Database name to create (else, defaults to: `quix`)
 5. **\[Recommended, Optional\]** Enable state, otherwise changes will be lost on restart.  
     > Note: the necessary storage type may not be supported on all Quix Platforms.
 

--- a/docker/influxdb1/init.sh
+++ b/docker/influxdb1/init.sh
@@ -25,11 +25,10 @@ export INFLUXDB_DATA_WAL_DIR="$TARGET_DIR/wal"
 
 # The v1 image initialises itself from INFLUXDB_ADMIN_USER / INFLUXDB_ADMIN_PASSWORD /
 # INFLUXDB_DB, but the connection is defined once in the shared influxdb1-config Variable
-# Group as INFLUXDB1_*. Map one onto the other, keeping the legacy names as a fallback so
-# deployments created before the rename keep working.
-export INFLUXDB_ADMIN_USER="${INFLUXDB1_USERNAME:-$INFLUXDB_ADMIN_USER}"
-export INFLUXDB_ADMIN_PASSWORD="${INFLUXDB1_PASSWORD:-$INFLUXDB_ADMIN_PASSWORD}"
-export INFLUXDB_DB="${INFLUXDB1_DATABASE:-$INFLUXDB_DB}"
+# Group as INFLUXDB1_*, so that clients read the same values. Map one onto the other.
+export INFLUXDB_ADMIN_USER="$INFLUXDB1_USERNAME"
+export INFLUXDB_ADMIN_PASSWORD="$INFLUXDB1_PASSWORD"
+export INFLUXDB_DB="$INFLUXDB1_DATABASE"
 
 # Fail if admin user or password is not set or empty
 if [ -z "$INFLUXDB_ADMIN_USER" ]; then

--- a/docker/influxdb1/init.sh
+++ b/docker/influxdb1/init.sh
@@ -23,13 +23,21 @@ export INFLUXDB_DATA_DIR="$TARGET_DIR/data"
 export INFLUXDB_META_DIR="$TARGET_DIR/meta"
 export INFLUXDB_DATA_WAL_DIR="$TARGET_DIR/wal"
 
+# The v1 image initialises itself from INFLUXDB_ADMIN_USER / INFLUXDB_ADMIN_PASSWORD /
+# INFLUXDB_DB, but the connection is defined once in the shared influxdb1-config Variable
+# Group as INFLUXDB1_*. Map one onto the other, keeping the legacy names as a fallback so
+# deployments created before the rename keep working.
+export INFLUXDB_ADMIN_USER="${INFLUXDB1_USERNAME:-$INFLUXDB_ADMIN_USER}"
+export INFLUXDB_ADMIN_PASSWORD="${INFLUXDB1_PASSWORD:-$INFLUXDB_ADMIN_PASSWORD}"
+export INFLUXDB_DB="${INFLUXDB1_DATABASE:-$INFLUXDB_DB}"
+
 # Fail if admin user or password is not set or empty
 if [ -z "$INFLUXDB_ADMIN_USER" ]; then
-  echo "❌ ERROR: INFLUXDB_ADMIN_USER is required but not set or empty"
+  echo "❌ ERROR: INFLUXDB1_USERNAME is required but not set or empty"
   exit 1
 fi
 if [ -z "$INFLUXDB_ADMIN_PASSWORD" ]; then
-  echo "❌ ERROR: INFLUXDB_ADMIN_PASSWORD is required but not set or empty"
+  echo "❌ ERROR: INFLUXDB1_PASSWORD is required but not set or empty"
   exit 1
 fi
 

--- a/docker/influxdb1/library.json
+++ b/docker/influxdb1/library.json
@@ -3,8 +3,12 @@
   "name": "InfluxDB v1",
   "language": "docker",
   "tags": {
-    "Category": ["Time series DB"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Time series DB"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run InfluxDB v1 in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -19,8 +23,7 @@
     "UrlPrefix": "influxdb",
     "Network": {
       "ServiceName": "influxdb",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 80,
           "TargetPort": 8086
@@ -30,27 +33,50 @@
   },
   "Variables": [
     {
-      "Name": "INFLUXDB_ADMIN_USER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Admin username to initialize InfluxDB with",
-      "DefaultValue": "admin",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_ADMIN_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Admin password to initialize InfluxDB with",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_DB",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Database name to initialize InfluxDB with",
-      "DefaultValue": "quix",
-      "Required": false
+      "Name": "INFLUXDB1_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "InfluxDB v1 connection details and admin credentials from a shared Variable Group.",
+      "VariableGroupId": "influxdb1-config",
+      "VariableGroupName": "InfluxDB v1 config",
+      "VariableGroupDescription": "Shared InfluxDB v1 connection details and admin credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "INFLUXDB1_HOST",
+          "Description": "Host address of the InfluxDB v1 instance, including the http:// scheme",
+          "DefaultValue": "http://influxdb",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_PORT",
+          "Description": "Port of the InfluxDB v1 instance (80 for the bundled server on the internal Quix network)",
+          "DefaultValue": "80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_DATABASE",
+          "Description": "Database clients read and write, and the database the server is initialised with",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_USERNAME",
+          "Description": "Admin username the server is initialised with, and that clients authenticate as",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_PASSWORD",
+          "Description": "Admin password the server is initialised with, and that clients authenticate with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
-  ]  
+  ]
 }

--- a/docker/influxdb2/README.md
+++ b/docker/influxdb2/README.md
@@ -2,11 +2,28 @@
 
 This sample demonstrates how to deploy and use InfluxDB v2 as a time series database in your Quix Cloud pipeline. Please note: this image is provided by Influx and is offered as-is, with no specific support from Quix. For any support, contact Influx directly.
 
+## Configuration
+
+This sample uses the shared **`influxdb2-config`** variable group, so the server, the
+InfluxDB v2 Source and Grafana all read the same connection details and token. Assign the
+group to this deployment (or your project/environment) with:
+
+- **INFLUXDB2_HOST** — base URL clients use to reach the server, including scheme and port (default `http://influxdb:80`)
+- **INFLUXDB2_TOKEN** — admin token, secret. Seeds server auth on first boot and authenticates clients
+- **INFLUXDB2_ORG** — organization the server is initialised with, and that clients query (default `quix`)
+- **INFLUXDB2_BUCKET** — bucket the server is initialised with, and that clients read and write (default `demo`)
+- **INFLUXDB2_USERNAME** — admin username the server is initialised with (default `admin`)
+- **INFLUXDB2_PASSWORD** — admin password for that user, secret
+
+The v2 image is set up from `DOCKER_INFLUXDB_INIT_*`; `init.sh` maps the group values onto
+those names, and falls back to them directly so deployments created before the group was
+introduced keep working.
+
 ## How to Run
 
 1. Create an account or log in to your [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) account and navigate to the Code Samples section.
 2. Click `Deploy` to launch a pre-built container in Quix.
-3. Complete the required environment variables to configure your InfluxDB instance.
+3. Assign the `influxdb2-config` variable group, setting at least `INFLUXDB2_TOKEN` and `INFLUXDB2_PASSWORD`.
 4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 ## How to Use

--- a/docker/influxdb2/init.sh
+++ b/docker/influxdb2/init.sh
@@ -42,6 +42,21 @@ if [ "$ACTUAL_DIR_GID" -ne "$TARGET_USER_GID" ] && [ "$ACTUAL_DIR_GID" -ne 0 ]; 
   }
 fi
 
+# The v2 image is set up from DOCKER_INFLUXDB_INIT_*, but the connection is defined once
+# in the shared influxdb2-config Variable Group as INFLUXDB2_*. Map one onto the other,
+# keeping the legacy names as a fallback so deployments created before the rename keep
+# working. Username and org also have image defaults set in the dockerfile.
+export DOCKER_INFLUXDB_INIT_ADMIN_TOKEN="${INFLUXDB2_TOKEN:-$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}"
+export DOCKER_INFLUXDB_INIT_PASSWORD="${INFLUXDB2_PASSWORD:-$DOCKER_INFLUXDB_INIT_PASSWORD}"
+export DOCKER_INFLUXDB_INIT_BUCKET="${INFLUXDB2_BUCKET:-$DOCKER_INFLUXDB_INIT_BUCKET}"
+export DOCKER_INFLUXDB_INIT_USERNAME="${INFLUXDB2_USERNAME:-$DOCKER_INFLUXDB_INIT_USERNAME}"
+export DOCKER_INFLUXDB_INIT_ORG="${INFLUXDB2_ORG:-$DOCKER_INFLUXDB_INIT_ORG}"
+
+if [ -z "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN" ] || [ -z "$DOCKER_INFLUXDB_INIT_PASSWORD" ]; then
+  echo "❌ ERROR: INFLUXDB2_TOKEN and INFLUXDB2_PASSWORD are required to set up InfluxDB v2"
+  exit 1
+fi
+
 # Launch the influx setup in the background.
 (
     #echo "Waiting for InfluxDB to be available at localhost:8086..."

--- a/docker/influxdb2/init.sh
+++ b/docker/influxdb2/init.sh
@@ -43,19 +43,22 @@ if [ "$ACTUAL_DIR_GID" -ne "$TARGET_USER_GID" ] && [ "$ACTUAL_DIR_GID" -ne 0 ]; 
 fi
 
 # The v2 image is set up from DOCKER_INFLUXDB_INIT_*, but the connection is defined once
-# in the shared influxdb2-config Variable Group as INFLUXDB2_*. Map one onto the other,
-# keeping the legacy names as a fallback so deployments created before the rename keep
-# working. Username and org also have image defaults set in the dockerfile.
-export DOCKER_INFLUXDB_INIT_ADMIN_TOKEN="${INFLUXDB2_TOKEN:-$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}"
-export DOCKER_INFLUXDB_INIT_PASSWORD="${INFLUXDB2_PASSWORD:-$DOCKER_INFLUXDB_INIT_PASSWORD}"
-export DOCKER_INFLUXDB_INIT_BUCKET="${INFLUXDB2_BUCKET:-$DOCKER_INFLUXDB_INIT_BUCKET}"
-export DOCKER_INFLUXDB_INIT_USERNAME="${INFLUXDB2_USERNAME:-$DOCKER_INFLUXDB_INIT_USERNAME}"
-export DOCKER_INFLUXDB_INIT_ORG="${INFLUXDB2_ORG:-$DOCKER_INFLUXDB_INIT_ORG}"
+# in the shared influxdb2-config Variable Group as INFLUXDB2_*, so that clients and
+# Grafana read the same values. Map one onto the other. These overwrite the dockerfile's
+# ENV defaults, so every one is validated below rather than silently becoming empty.
+export DOCKER_INFLUXDB_INIT_ADMIN_TOKEN="$INFLUXDB2_TOKEN"
+export DOCKER_INFLUXDB_INIT_PASSWORD="$INFLUXDB2_PASSWORD"
+export DOCKER_INFLUXDB_INIT_BUCKET="$INFLUXDB2_BUCKET"
+export DOCKER_INFLUXDB_INIT_USERNAME="$INFLUXDB2_USERNAME"
+export DOCKER_INFLUXDB_INIT_ORG="$INFLUXDB2_ORG"
 
-if [ -z "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN" ] || [ -z "$DOCKER_INFLUXDB_INIT_PASSWORD" ]; then
-  echo "❌ ERROR: INFLUXDB2_TOKEN and INFLUXDB2_PASSWORD are required to set up InfluxDB v2"
-  exit 1
-fi
+for required in INFLUXDB2_TOKEN INFLUXDB2_PASSWORD INFLUXDB2_BUCKET INFLUXDB2_USERNAME INFLUXDB2_ORG; do
+  eval "value=\$$required"
+  if [ -z "$value" ]; then
+    echo "❌ ERROR: $required is required to set up InfluxDB v2 - is the influxdb2-config variable group assigned?"
+    exit 1
+  fi
+done
 
 # Launch the influx setup in the background.
 (

--- a/docker/influxdb2/library.json
+++ b/docker/influxdb2/library.json
@@ -3,8 +3,12 @@
   "name": "InfluxDB v2",
   "language": "docker",
   "tags": {
-    "Category": ["Time series DB"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Time series DB"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run InfluxDB v2 in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -19,8 +23,7 @@
     "UrlPrefix": "influxdb",
     "Network": {
       "ServiceName": "influxdb",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 80,
           "TargetPort": 8086
@@ -30,28 +33,57 @@
   },
   "Variables": [
     {
-      "Name": "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Default Admin Token to initialize Influx with",
-      "DefaultValue": "INFLUX_ADMIN_TOKEN",
-      "Required": true
-    },
-    {
-      "Name": "DOCKER_INFLUXDB_INIT_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Default Admin password to initialize Influx with",
-      "DefaultValue": "ADMIN_PASSWORD",
-      "Required": true
-    },
-    {
-      "Name": "DOCKER_INFLUXDB_INIT_BUCKET",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Bucket Name to initialize Influx with",
-      "DefaultValue": "demo",
-      "Required": true
+      "Name": "INFLUXDB2_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "InfluxDB v2 connection details and admin token from a shared Variable Group.",
+      "VariableGroupId": "influxdb2-config",
+      "VariableGroupName": "InfluxDB v2 config",
+      "VariableGroupDescription": "Shared InfluxDB v2 connection details, admin token and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "INFLUXDB2_HOST",
+          "Description": "Base URL clients use to reach InfluxDB v2, including the http:// scheme and port",
+          "DefaultValue": "http://influxdb:80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_TOKEN",
+          "Description": "Admin token. Seeds server auth on first boot and authenticates clients",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_ORG",
+          "Description": "Organization the server is initialised with, and that clients query",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_BUCKET",
+          "Description": "Bucket the server is initialised with, and that clients read and write",
+          "DefaultValue": "demo",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_USERNAME",
+          "Description": "Admin username the server is initialised with",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_PASSWORD",
+          "Description": "Admin password the server is initialised with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
-  ]  
+  ]
 }

--- a/docker/influxdb3/library.json
+++ b/docker/influxdb3/library.json
@@ -33,7 +33,7 @@
       "Description": "Shared InfluxDB v3 connection details and admin token (used by this server and by every client that reads/writes it)",
       "VariableGroupId": "influxdb3-config",
       "VariableGroupName": "InfluxDB v3 config",
-      "VariableGroupDescription": "Shared InfluxDB v3 connection details and admin token (used by this server and by every client that reads/writes it)",
+      "VariableGroupDescription": "Shared InfluxDB v3 connection details and admin token, used by the server and all its clients",
       "Required": true,
       "Variables": [
         {

--- a/docker/minio/README.md
+++ b/docker/minio/README.md
@@ -6,22 +6,27 @@ This sample demonstrates how to deploy and use MinIO in your pipeline.
 
 This deployment will work seamlessly with the Quix Cloud Amazon S3 Source/Sink connectors.
 
-Simply set your environment variables for either connector:
+Assign the same `aws-connection` variable group to MinIO and to either connector, and they
+share one set of credentials - MinIO's root user *is* the S3 access key:
+
+```shell
+AWS_ACCESS_KEY_ID="<MINIO ROOT USERNAME>"      # seeds MinIO's root user
+AWS_SECRET_ACCESS_KEY="<MINIO ROOT PASSWORD>"  # seeds MinIO's root password
+AWS_ENDPOINT_URL="http://minio:80"
+AWS_REGION="<ANY STR>"
+```
+
+The bucket stays per-deployment on the connector:
 
 ```shell
 S3_BUCKET="<MINIO BUCKET NAME>"
-AWS_ENDPOINT_URL="http://minio:80"
-AWS_REGION_NAME="<ANY STR>"
-AWS_ACCESS_KEY_ID: "<MINIO ROOT USERNAME>"
-AWS_SECRET_ACCESS_KEY: "<MINIO ROOT PASSWORD>"
-
 ```
 
 ## How to Run
 
 1. Log in or sign up at [Quix](https://portal.platform.quix.io/signup?xlink=github) and navigate to the Code Samples section.
 2. Click **Deploy** to launch a pre-built container.
-3. Fill in the required environment variables for your MinIO instance.
+3. Assign the `aws-connection` variable group, setting at least `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 For more configuration options and details, refer to [MinIO's Docker Hub](https://hub.docker.com/r/minio/minio).

--- a/docker/minio/init.sh
+++ b/docker/minio/init.sh
@@ -20,4 +20,16 @@ if [ ! -d "$TARGET_DIR" ]; then
   }
 fi
 
+# MinIO's root user is also the S3 access key that clients authenticate with, so it comes
+# from the shared aws-connection Variable Group (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY).
+# Fall back to the legacy MINIO_ROOT_USER / MINIO_ROOT_PASSWORD names so deployments
+# created before the rename keep working.
+export MINIO_ROOT_USER="${AWS_ACCESS_KEY_ID:-$MINIO_ROOT_USER}"
+export MINIO_ROOT_PASSWORD="${AWS_SECRET_ACCESS_KEY:-$MINIO_ROOT_PASSWORD}"
+
+if [ -z "$MINIO_ROOT_USER" ] || [ -z "$MINIO_ROOT_PASSWORD" ]; then
+  echo "❌ ERROR: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required to initialise MinIO"
+  exit 1
+fi
+
 exec /bin/sh -c "minio server $TARGET_DIR --console-address ':9001'"

--- a/docker/minio/init.sh
+++ b/docker/minio/init.sh
@@ -21,11 +21,10 @@ if [ ! -d "$TARGET_DIR" ]; then
 fi
 
 # MinIO's root user is also the S3 access key that clients authenticate with, so it comes
-# from the shared aws-connection Variable Group (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY).
-# Fall back to the legacy MINIO_ROOT_USER / MINIO_ROOT_PASSWORD names so deployments
-# created before the rename keep working.
-export MINIO_ROOT_USER="${AWS_ACCESS_KEY_ID:-$MINIO_ROOT_USER}"
-export MINIO_ROOT_PASSWORD="${AWS_SECRET_ACCESS_KEY:-$MINIO_ROOT_PASSWORD}"
+# from the shared aws-connection Variable Group (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+# and the S3 connectors read the same values. Map them onto the names minio expects.
+export MINIO_ROOT_USER="$AWS_ACCESS_KEY_ID"
+export MINIO_ROOT_PASSWORD="$AWS_SECRET_ACCESS_KEY"
 
 if [ -z "$MINIO_ROOT_USER" ] || [ -z "$MINIO_ROOT_PASSWORD" ]; then
   echo "❌ ERROR: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required to initialise MinIO"

--- a/docker/minio/library.json
+++ b/docker/minio/library.json
@@ -3,8 +3,12 @@
   "name": "MinIO",
   "language": "docker",
   "tags": {
-    "Category": ["Database"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Database"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run a localized S3-compatible datastore in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -17,8 +21,7 @@
     "Replicas": 1,
     "Network": {
       "ServiceName": "minio",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 80,
           "TargetPort": 9000
@@ -28,19 +31,50 @@
   },
   "Variables": [
     {
-      "Name": "MINIO_ROOT_USER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The root username to initialize Minio with",
-      "DefaultValue": "admin",
-      "Required": true
-    },
-    {
-      "Name": "MINIO_ROOT_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The root password to initialize Minio with",
-      "Required": true
+      "Name": "AWS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "AWS credentials and region from a shared Variable Group.",
+      "VariableGroupId": "aws-connection",
+      "VariableGroupName": "AWS Connection",
+      "VariableGroupDescription": "Shared AWS credentials, region and optional S3-compatible endpoint.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "AWS_ACCESS_KEY_ID",
+          "Description": "Your AWS access key ID",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SECRET_ACCESS_KEY",
+          "Description": "Your AWS secret access key",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_REGION",
+          "Description": "The AWS region your resources live in",
+          "DefaultValue": "us-east-1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SESSION_TOKEN",
+          "Description": "AWS session token, for temporary credentials only",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "AWS_ENDPOINT_URL",
+          "Description": "Custom endpoint for S3-compatible storage such as MinIO. Leave empty for AWS",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     }
-  ]  
+  ]
 }

--- a/docker/mongodb/README.md
+++ b/docker/mongodb/README.md
@@ -6,15 +6,14 @@ This sample demonstrates how to deploy and use MongoDB in your pipeline. Please 
 
 This deployment will work seamlessly with the [Quix Cloud MongoDB sink connector](https://github.com/quixio/quix-samples/tree/main/python/destinations/mongodb).
 
-Simply provide the following arguments to the connector, 
-where `username` and `password` are the credentials used when 
-creating this service: 
+Assign the same `mongodb-connection` variable group to the connector and it picks up
+this service's connection automatically - no need to copy the values by hand:
 
 ```shell
-MONGODB_USERNAME="<YOUR USERNAME>"  # (default: "admin")
-MONGODB_PASSWORD="<YOUR PASSWORD>"
-MONGODB_HOST="mongodb"
-MONGODB_PORT="27017"
+MONGO_HOST="mongodb"      # the internal service name
+MONGO_PORT="27017"
+MONGO_USER="admin"
+MONGO_PASSWORD="<YOUR PASSWORD>"
 ```
 
 ## Configuration

--- a/docker/mongodb/README.md
+++ b/docker/mongodb/README.md
@@ -17,11 +17,26 @@ MONGODB_HOST="mongodb"
 MONGODB_PORT="27017"
 ```
 
+## Configuration
+
+This sample uses the shared **`mongodb-connection`** variable group, so the server and
+every client (such as the MongoDB Sink) read the same connection details. Assign the group
+to this deployment (or your project/environment) with:
+
+- **MONGO_HOST** — host address clients use to reach the server (default `mongodb`, the internal service name)
+- **MONGO_PORT** — port clients connect on (default `27017`)
+- **MONGO_USER** — root username the server is initialised with (default `admin`)
+- **MONGO_PASSWORD** — root password for that user, secret
+
+The mongo image itself reads `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`;
+`init.sh` maps the group values onto those names, and falls back to them directly so
+deployments created before the group was introduced keep working.
+
 ## How to Run
 
 1. Log in or sign up at [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) and navigate to the Code Samples section.
 2. Click **Deploy** to launch a pre-built container.
-3. Fill in the required environment variables for your MongoDB instance.
+3. Assign the `mongodb-connection` variable group, setting at least `MONGO_PASSWORD`.
 4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 For more configuration options and details, refer to [Mongo Docker Hub](https://hub.docker.com/_/mongo).

--- a/docker/mongodb/init.sh
+++ b/docker/mongodb/init.sh
@@ -44,14 +44,13 @@ fi
 
 # The mongo image initialises its root user from MONGO_INITDB_ROOT_USERNAME /
 # MONGO_INITDB_ROOT_PASSWORD, but the connection is defined once in the shared
-# mongodb-connection Variable Group as MONGO_USER / MONGO_PASSWORD. Map one onto the
-# other, keeping the legacy names as a fallback so deployments created before the
-# rename keep working.
-export MONGO_INITDB_ROOT_USERNAME="${MONGO_USER:-$MONGO_INITDB_ROOT_USERNAME}"
-export MONGO_INITDB_ROOT_PASSWORD="${MONGO_PASSWORD:-$MONGO_INITDB_ROOT_PASSWORD}"
+# mongodb-connection Variable Group as MONGO_USER / MONGO_PASSWORD, so that the sink and
+# other clients read the same values. Map one onto the other.
+export MONGO_INITDB_ROOT_USERNAME="$MONGO_USER"
+export MONGO_INITDB_ROOT_PASSWORD="$MONGO_PASSWORD"
 
 if [ -z "$MONGO_INITDB_ROOT_USERNAME" ] || [ -z "$MONGO_INITDB_ROOT_PASSWORD" ]; then
-  echo "❌ ERROR: MONGO_USER and MONGO_PASSWORD are required to initialise MongoDB"
+  echo "❌ ERROR: MONGO_USER and MONGO_PASSWORD are required - is the mongodb-connection variable group assigned?"
   exit 1
 fi
 

--- a/docker/mongodb/init.sh
+++ b/docker/mongodb/init.sh
@@ -42,4 +42,17 @@ if [ "$ACTUAL_DIR_GID" -ne "$TARGET_USER_GID" ] && [ "$ACTUAL_DIR_GID" -ne 0 ]; 
   }
 fi
 
+# The mongo image initialises its root user from MONGO_INITDB_ROOT_USERNAME /
+# MONGO_INITDB_ROOT_PASSWORD, but the connection is defined once in the shared
+# mongodb-connection Variable Group as MONGO_USER / MONGO_PASSWORD. Map one onto the
+# other, keeping the legacy names as a fallback so deployments created before the
+# rename keep working.
+export MONGO_INITDB_ROOT_USERNAME="${MONGO_USER:-$MONGO_INITDB_ROOT_USERNAME}"
+export MONGO_INITDB_ROOT_PASSWORD="${MONGO_PASSWORD:-$MONGO_INITDB_ROOT_PASSWORD}"
+
+if [ -z "$MONGO_INITDB_ROOT_USERNAME" ] || [ -z "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+  echo "❌ ERROR: MONGO_USER and MONGO_PASSWORD are required to initialise MongoDB"
+  exit 1
+fi
+
 exec su -s /bin/sh $TARGET_USER -c "docker-entrypoint.sh mongod --bind_ip_all --dbpath $TARGET_DIR"

--- a/docker/mongodb/library.json
+++ b/docker/mongodb/library.json
@@ -3,8 +3,12 @@
   "name": "MongoDB",
   "language": "docker",
   "tags": {
-    "Category": ["Database"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Database"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run MongoDB in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -17,8 +21,7 @@
     "Replicas": 1,
     "Network": {
       "ServiceName": "mongodb",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 27017,
           "TargetPort": 27017
@@ -28,20 +31,43 @@
   },
   "Variables": [
     {
-      "Name": "MONGO_INITDB_ROOT_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The root username to initialize MongoDB with",
-      "DefaultValue": "admin",
-      "Required": true
-    },
-    {
-      "Name": "MONGO_INITDB_ROOT_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The root password to initialize MongoDB with",
-      "DefaultValue": "MONGO_ROOT_PASSWORD",
-      "Required": true
+      "Name": "MONGODB_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "MongoDB connection (host, port, credentials) from a shared Variable Group.",
+      "VariableGroupId": "mongodb-connection",
+      "VariableGroupName": "MongoDB Connection",
+      "VariableGroupDescription": "Shared MongoDB connection details.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "MONGO_HOST",
+          "Description": "MongoDB host name",
+          "DefaultValue": "mongodb",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "MONGO_PORT",
+          "Description": "MongoDB host port",
+          "DefaultValue": "27017",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "MONGO_USER",
+          "Description": "MongoDB username",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "MONGO_PASSWORD",
+          "Description": "MongoDB password",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
-  ]  
+  ]
 }

--- a/docker/mqtt/README.md
+++ b/docker/mqtt/README.md
@@ -28,9 +28,7 @@ deployment (or your project/environment) with:
 - **mqtt_password** — password for that user, secret
 
 `mosquitto.conf` sets `allow_anonymous false`, so both a username and a password are
-required and the container exits with an error if either is empty. The legacy
-`MQTT_USERNAME` / `MQTT_PASSWORD` variables still work for deployments created before the
-group was introduced.
+required and the container exits with an error if either is empty.
 
 ## How to Run
 

--- a/docker/mqtt/README.md
+++ b/docker/mqtt/README.md
@@ -6,22 +6,37 @@ This sample demonstrates how to deploy and use Mosquitto's MQTT server in your p
 
 This deployment will work seamlessly with the [Quix Cloud MQTT sink connector](https://github.com/quixio/quix-samples/tree/main/python/destinations/mqtt).
 
-Simply provide the following arguments to the connector, 
-where `username` and `password` are the credentials used when 
-creating this service: 
+Assign the same `mqtt-connection` variable group to the connector and it picks up the
+matching address and credentials automatically - no need to copy the values by hand:
 
 ```shell
-MQTT_USERNAME="<YOUR USERNAME>"  # (default: "admin")
-MQTT_PASSWORD="<YOUR PASSWORD>"
-MQTT_HOST="mqtt"
-MQTT_PORT="1883"
+mqtt_server="mqtt"      # the internal service name
+mqtt_port="1883"
+mqtt_username="admin"
+mqtt_password="<YOUR PASSWORD>"
 ```
+
+## Configuration
+
+This sample uses the shared **`mqtt-connection`** variable group, so the broker and every
+client (source/sink) read the same address and credentials. Assign the group to this
+deployment (or your project/environment) with:
+
+- **mqtt_server** — host address clients use to reach the broker (default `mqtt`, the internal service name)
+- **mqtt_port** — port clients connect on (default `1883`)
+- **mqtt_username** — username the broker is seeded with, and that clients authenticate as (default `admin`)
+- **mqtt_password** — password for that user, secret
+
+`mosquitto.conf` sets `allow_anonymous false`, so both a username and a password are
+required and the container exits with an error if either is empty. The legacy
+`MQTT_USERNAME` / `MQTT_PASSWORD` variables still work for deployments created before the
+group was introduced.
 
 ## How to Run
 
 1. Log in or sign up at [Quix](https://portal.platform.quix.io/signup?xlink=github) and navigate to the Code Samples section.
 2. Click **Deploy** to launch a pre-built container.
-3. Fill in the required environment variables for your MongoDB instance.
+3. Assign the `mqtt-connection` variable group, setting at least `mqtt_password`.
 4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 For more configuration options and details, refer to [Mosquitto Docker Hub](https://hub.docker.com/_/eclipse-mosquitto).

--- a/docker/mqtt/init.sh
+++ b/docker/mqtt/init.sh
@@ -43,5 +43,16 @@ if [ "$ACTUAL_DIR_GID" -ne "$TARGET_USER_GID" ] && [ "$ACTUAL_DIR_GID" -ne 0 ]; 
 fi
 
 su -s /bin/sh $TARGET_USER -c "mkdir -p $TARGET_DIR/config/ $TARGET_DIR/log/ $TARGET_DIR/data/"
-su -s /bin/sh $TARGET_USER -c "mosquitto_passwd -b -c $TARGET_DIR/config/passwd $MQTT_USERNAME $MQTT_PASSWORD"
+# Credentials come from the shared mqtt-connection Variable Group (mqtt_username /
+# mqtt_password). Fall back to the legacy MQTT_USERNAME / MQTT_PASSWORD names so
+# deployments created before the rename keep working.
+BROKER_USERNAME="${mqtt_username:-$MQTT_USERNAME}"
+BROKER_PASSWORD="${mqtt_password:-$MQTT_PASSWORD}"
+
+if [ -z "$BROKER_USERNAME" ] || [ -z "$BROKER_PASSWORD" ]; then
+  echo "❌ ERROR: mqtt_username and mqtt_password are required (mosquitto.conf sets allow_anonymous false)"
+  exit 1
+fi
+
+su -s /bin/sh $TARGET_USER -c "mosquitto_passwd -b -c $TARGET_DIR/config/passwd $BROKER_USERNAME $BROKER_PASSWORD"
 exec su -s /bin/sh $TARGET_USER -c "mosquitto -c /mosquitto/config/mosquitto.conf"

--- a/docker/mqtt/init.sh
+++ b/docker/mqtt/init.sh
@@ -43,11 +43,10 @@ if [ "$ACTUAL_DIR_GID" -ne "$TARGET_USER_GID" ] && [ "$ACTUAL_DIR_GID" -ne 0 ]; 
 fi
 
 su -s /bin/sh $TARGET_USER -c "mkdir -p $TARGET_DIR/config/ $TARGET_DIR/log/ $TARGET_DIR/data/"
-# Credentials come from the shared mqtt-connection Variable Group (mqtt_username /
-# mqtt_password). Fall back to the legacy MQTT_USERNAME / MQTT_PASSWORD names so
-# deployments created before the rename keep working.
-BROKER_USERNAME="${mqtt_username:-$MQTT_USERNAME}"
-BROKER_PASSWORD="${mqtt_password:-$MQTT_PASSWORD}"
+# Credentials come from the shared mqtt-connection Variable Group, so the broker and
+# every client (source/sink) authenticate with the same user.
+BROKER_USERNAME="$mqtt_username"
+BROKER_PASSWORD="$mqtt_password"
 
 if [ -z "$BROKER_USERNAME" ] || [ -z "$BROKER_PASSWORD" ]; then
   echo "❌ ERROR: mqtt_username and mqtt_password are required (mosquitto.conf sets allow_anonymous false)"

--- a/docker/mqtt/library.json
+++ b/docker/mqtt/library.json
@@ -3,8 +3,12 @@
   "name": "MQTT Broker",
   "language": "docker",
   "tags": {
-    "Category": ["Server"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Server"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run Mosquitto's MQTT broker in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -17,8 +21,7 @@
     "Replicas": 1,
     "Network": {
       "ServiceName": "mqtt",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 1883,
           "TargetPort": 1883
@@ -28,19 +31,57 @@
   },
   "Variables": [
     {
-      "Name": "MQTT_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The username to connect to the server with",
-      "DefaultValue": "admin",
-      "Required": true
-    },
-    {
-      "Name": "MQTT_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The password to connect to the server with",
-      "Required": true
+      "Name": "MQTT_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "MQTT broker address, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "mqtt-connection",
+      "VariableGroupName": "MQTT Connection",
+      "VariableGroupDescription": "Shared MQTT broker address, port and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "mqtt_server",
+          "Description": "Host address of your MQTT broker, without the protocol prefix",
+          "DefaultValue": "mqtt",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_port",
+          "Description": "Port of your MQTT broker",
+          "DefaultValue": "1883",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_username",
+          "Description": "Username to connect to the broker with",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_password",
+          "Description": "Password to connect to the broker with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_version",
+          "Description": "MQTT protocol version. One of: 3.1, 3.1.1, 5",
+          "DefaultValue": "3.1.1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_tls_enabled",
+          "Description": "Enable TLS for the broker connection. One of: true, false. The bundled Mosquitto broker listens plaintext on 1883, so this defaults to false",
+          "DefaultValue": "false",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     }
-  ]  
+  ]
 }

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -4,23 +4,40 @@ This sample demonstrates how to deploy and use a PostgreSQL database in your Qui
 
 Please note: this image is provided by Postgres and is offered as-is, with no specific support from Quix. For any support, contact Postgres directly.
 
+## Configuration
+
+This sample uses the shared **`postgres-connection`** variable group, so the server and
+every client (sink, CDC source) read the same connection details. Assign the group to this
+deployment (or your project/environment) with:
+
+- **POSTGRES_HOST** — host address clients use to reach the server (default `postgresql`, the internal service name)
+- **POSTGRES_PORT** — port clients connect on (default `80`, which maps to 5432 in the container)
+- **POSTGRES_DB** — database the server is initialised with, and that clients connect to (default `quix`)
+- **POSTGRES_USER** — root username the server is initialised with (default `admin`)
+- **POSTGRES_PASSWORD** — root password for that user, secret
+
+The postgres image reads `POSTGRES_USER`, `POSTGRES_PASSWORD` and `POSTGRES_DB` under
+exactly those names, so the group values reach it directly with no mapping.
+
 ## How to Run
 
 1. Create an account or log in to your [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) account and navigate to the Code Samples section.
-2. Click `Deploy` to launch a pre-built container in Quix.
-3. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
+2. Assign the `postgres-connection` variable group, setting at least `POSTGRES_PASSWORD`.
+3. Click `Deploy` to launch a pre-built container in Quix.
+4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 ## How to Use
 To interact with PosgreSQL from your pipeline, either use one of the no-code [PostgreSQL connectors](https://quix.io/integrations?category=SQL+DB)
 in Quix Cloud or use a Quix Streams [PostgreSQLSink](https://quix.io/docs/quix-streams/connectors/sinks/postgresql-sink.html) directly.
 
-Use the following values to connect:
+Assign the same `postgres-connection` variable group to those clients so they connect with
+the matching host, port, database and credentials — no need to copy the values by hand:
 ```shell
-host="postgresql"
-port=80
-username="admin"  # or your POSTGRES_USER value
-password="<YOUR PASSWORD>" # your POSTGRES_PASSWORD value
-db="quix"  # or your POSTGRES_DB value
+host="$POSTGRES_HOST"          # default "postgresql"
+port="$POSTGRES_PORT"          # default 80
+username="$POSTGRES_USER"      # default "admin"
+password="$POSTGRES_PASSWORD"
+db="$POSTGRES_DB"              # default "quix"
 ```
 
 ## Contribute

--- a/docker/postgres/library.json
+++ b/docker/postgres/library.json
@@ -3,8 +3,12 @@
   "name": "postgreSQL",
   "language": "docker",
   "tags": {
-    "Category": ["Database"],
-    "Type": ["Auxiliary Services"]
+    "Category": [
+      "Database"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ]
   },
   "shortDescription": "Run postgreSQL in your pipeline.",
   "DefaultFile": "dockerfile",
@@ -17,8 +21,7 @@
     "Replicas": 1,
     "Network": {
       "ServiceName": "postgresql",
-      "Ports":
-      [
+      "Ports": [
         {
           "Port": 80,
           "TargetPort": 5432
@@ -28,27 +31,50 @@
   },
   "Variables": [
     {
-      "Name": "POSTGRES_USER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The root username to initialize PostgreSQL with",
-      "DefaultValue": "admin",
-      "Required": true
-    },
-    {
-      "Name": "POSTGRES_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The root password to initialize MongoDB with",
-      "Required": true
-    },
+      "Name": "POSTGRES_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "PostgreSQL host, port, database and credentials from a shared Variable Group.",
+      "VariableGroupId": "postgres-connection",
+      "VariableGroupName": "PostgreSQL Connection",
+      "VariableGroupDescription": "Shared PostgreSQL host, port, database and credentials.",
+      "Required": true,
+      "Variables": [
         {
-      "Name": "POSTGRES_DB",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The default database name to initialize PostgreSQL with",
-      "DefaultValue": "quix",
-      "Required": true
+          "Key": "POSTGRES_HOST",
+          "Description": "Host address of the PostgreSQL instance",
+          "DefaultValue": "postgresql",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_PORT",
+          "Description": "Port of the PostgreSQL instance (80 for the bundled server on the internal Quix network)",
+          "DefaultValue": "80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_DB",
+          "Description": "Database name to connect to, and to initialise the server with",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_USER",
+          "Description": "Username for the PostgreSQL database",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_PASSWORD",
+          "Description": "Password for the PostgreSQL database",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
   ]
 }

--- a/docker/tailscale_subnetrouter/README.md
+++ b/docker/tailscale_subnetrouter/README.md
@@ -34,6 +34,10 @@ The container supports the following environment variables:
 | `TAILSCALE_SOCKS5_PORT` | Port for the SOCKS5 proxy | 1055 |
 | `TAILSCALE_EXTRA_ARGS` | Additional arguments to pass to "tailscale up" command | "" |
 
+These come from the shared **`tailscale-auth`** Variable Group (Tailscale Auth), so the connection is defined once per environment rather than per deployment:
+
+- `TS_AUTHKEY`
+
 ## Usage
 
 The container is designed to run as a service in Quix. It will:

--- a/docker/tailscale_subnetrouter/library.json
+++ b/docker/tailscale_subnetrouter/library.json
@@ -3,9 +3,15 @@
   "name": "Tailscale Subnet Router",
   "language": "docker",
   "tags": {
-    "Pipeline Stage": ["Infrastructure"],
-    "Type": ["Auxiliary Services"],
-    "Category": ["Network"]
+    "Pipeline Stage": [
+      "Infrastructure"
+    ],
+    "Type": [
+      "Auxiliary Services"
+    ],
+    "Category": [
+      "Network"
+    ]
   },
   "shortDescription": "Tailscale subnet router to access private network resources securely.",
   "DefaultFile": "start.sh",
@@ -14,12 +20,22 @@
   "RunEntryPoint": "dockerfile",
   "Variables": [
     {
-      "Name": "TS_AUTHKEY",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Tailscale authentication key for connecting to your tailnet",
-      "DefaultValue": "TS_AUTHKEY",
-      "Required": true
+      "Name": "TAILSCALE_AUTH",
+      "InputType": "VariableGroup",
+      "Description": "Tailscale auth key from a shared Variable Group.",
+      "VariableGroupId": "tailscale-auth",
+      "VariableGroupName": "Tailscale Auth",
+      "VariableGroupDescription": "Shared Tailscale auth key.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "TS_AUTHKEY",
+          "Description": "Tailscale auth key used to join the tailnet",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "TAILSCALE_HOSTNAME",

--- a/managed/backup-manager-prebuilt/README.md
+++ b/managed/backup-manager-prebuilt/README.md
@@ -89,6 +89,11 @@ All configuration is via environment variables, set on the deployment. Every var
 
 ### MongoDB Metadata Backend (only when `METADATA_BACKEND=mongo`)
 
+These come from the shared **`mongodb-metadata-connection`** Variable Group. This is the
+manager's *own* metadata store, which is why it has its own group rather than sharing
+`mongodb-connection` with the pipeline's data MongoDB - pointing it at the data instance
+would put `backup_manager` collections inside your data database.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `METADATA_MONGO_HOST` | `metadata-mongodb` | Metadata MongoDB hostname |

--- a/managed/backup-manager-prebuilt/library.json
+++ b/managed/backup-manager-prebuilt/library.json
@@ -3,9 +3,15 @@
   "name": "MongoDB Backup Manager",
   "language": "docker",
   "tags": {
-    "Type": ["Auxiliary Services"],
-    "Category": ["NoSQL DB"],
-    "Complexity": ["Medium"]
+    "Type": [
+      "Auxiliary Services"
+    ],
+    "Category": [
+      "NoSQL DB"
+    ],
+    "Complexity": [
+      "Medium"
+    ]
   },
   "shortDescription": "Web-based tool for managing MongoDB backups across multiple servers with scheduling, restore, and encrypted credential storage.",
   "DefaultFile": "dockerfile",
@@ -19,41 +25,62 @@
       "Description": "Metadata storage backend: 'mongo' or 'json'",
       "DefaultValue": "json",
       "options": [
-        { "label": "json", "value": "json" },
-        { "label": "mongo", "value": "mongo" }
+        {
+          "label": "json",
+          "value": "json"
+        },
+        {
+          "label": "mongo",
+          "value": "mongo"
+        }
       ],
       "Required": true
     },
     {
-      "Name": "METADATA_MONGO_HOST",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Metadata MongoDB hostname (only when METADATA_BACKEND=mongo)",
-      "DefaultValue": "metadata-mongodb",
-      "Required": false
-    },
-    {
-      "Name": "METADATA_MONGO_PORT",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Metadata MongoDB port (only when METADATA_BACKEND=mongo)",
-      "DefaultValue": "27017",
-      "Required": false
-    },
-    {
-      "Name": "METADATA_MONGO_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Metadata MongoDB username (only when METADATA_BACKEND=mongo)",
-      "DefaultValue": "admin",
-      "Required": false
-    },
-    {
-      "Name": "METADATA_MONGO_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Metadata MongoDB password (only when METADATA_BACKEND=mongo)",
-      "Required": false
+      "Name": "MONGODB_METADATA_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "The backup manager's metadata MongoDB connection, from a shared Variable Group.",
+      "VariableGroupId": "mongodb-metadata-connection",
+      "VariableGroupName": "MongoDB Metadata Connection",
+      "VariableGroupDescription": "Shared MongoDB connection for the backup manager's own metadata store.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "METADATA_MONGO_HOST",
+          "Description": "Metadata MongoDB hostname (only when METADATA_BACKEND=mongo)",
+          "DefaultValue": "metadata-mongodb",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "METADATA_MONGO_PORT",
+          "Description": "Metadata MongoDB port",
+          "DefaultValue": "80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "METADATA_MONGO_USERNAME",
+          "Description": "Metadata MongoDB username",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "METADATA_MONGO_PASSWORD",
+          "Description": "Metadata MongoDB password",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "METADATA_MONGO_DATABASE",
+          "Description": "Database the backup manager stores its metadata in",
+          "DefaultValue": "backup_manager",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "SECRET_KEY",
@@ -94,7 +121,10 @@
     "Network": {
       "ServiceName": "backup-manager",
       "Ports": [
-        { "Port": 80, "TargetPort": 80 }
+        {
+          "Port": 80,
+          "TargetPort": 80
+        }
       ]
     },
     "blobStorage": {

--- a/nodejs/basic-react-template/src/App.js
+++ b/nodejs/basic-react-template/src/App.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import { QuixLiveService } from './services/quix.ts';
-import {Data} from '../src/Models/data.ts'
 
 function App() {
   const [activeStreams, setActiveStreams] = useState([]);

--- a/python/destinations/MQTT/README.md
+++ b/python/destinations/MQTT/README.md
@@ -25,10 +25,20 @@ The connector uses the following environment variables:
 
 - **input**: Name of the input topic to listen to.
 - **mqtt_topic_root**: The root for messages in MQTT, this can be anything.
-- **mqtt_server**: The address of your MQTT server.
-- **mqtt_port**: The port of your MQTT server.
-- **mqtt_username**: Username of your MQTT user.
-- **mqtt_password**: Password for the MQTT user.
+
+The broker connection comes from the shared **`mqtt-connection`** Variable Group, so this
+sink, the MQTT Source and the bundled Mosquitto broker all agree:
+
+- **mqtt_server**: Host address of your MQTT broker, without the protocol prefix (Default: `mqtt`)
+- **mqtt_port**: Port of your MQTT broker (Default: `1883`)
+- **mqtt_username**: Username to connect to the broker with (Default: `admin`)
+- **mqtt_password**: Password to connect to the broker with
+- **mqtt_version**: MQTT protocol version. One of `3.1`, `3.1.1`, `5` (Default: `3.1.1`)
+- **mqtt_tls_enabled**: Enable TLS. One of `true`, `false` (Default: `false`, since the
+  bundled Mosquitto broker listens plaintext on 1883)
+
+`mqtt_version` and `mqtt_tls_enabled` are free text inside the group rather than
+dropdowns - the group schema has no options list. Valid values are given above.
 
 ## Contribute
 

--- a/python/destinations/MQTT/library.json
+++ b/python/destinations/MQTT/library.json
@@ -35,71 +35,55 @@
       "Required": true
     },
     {
-      "Name": "mqtt_server",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The address of your MQTT server",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_port",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The port of your MQTT server",
-      "DefaultValue": "8883",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username of your MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_version",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "MQTT protocol version",
-      "DefaultValue": "3.1.1",
+      "Name": "MQTT_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "MQTT broker address, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "mqtt-connection",
+      "VariableGroupName": "MQTT Connection",
+      "VariableGroupDescription": "Shared MQTT broker address, port and credentials.",
       "Required": true,
-      "options": [
+      "Variables": [
         {
-          "label": "3.1",
-          "value": "3.1"
+          "Key": "mqtt_server",
+          "Description": "Host address of your MQTT broker, without the protocol prefix",
+          "DefaultValue": "mqtt",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "3.1.1",
-          "value": "3.1.1"
+          "Key": "mqtt_port",
+          "Description": "Port of your MQTT broker",
+          "DefaultValue": "1883",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "5",
-          "value": "5"
-        }
-      ]
-    },
-    {
-      "Name": "mqtt_tls_enabled",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "Enable TLS for MQTT connection",
-      "DefaultValue": "true",
-      "Required": false,
-      "options": [
-        {
-          "label": "true",
-          "value": "true"
+          "Key": "mqtt_username",
+          "Description": "Username to connect to the broker with",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": false
         },
         {
-          "label": "false",
-          "value": "false"
+          "Key": "mqtt_password",
+          "Description": "Password to connect to the broker with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_version",
+          "Description": "MQTT protocol version. One of: 3.1, 3.1.1, 5",
+          "DefaultValue": "3.1.1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_tls_enabled",
+          "Description": "Enable TLS for the broker connection. One of: true, false. The bundled Mosquitto broker listens plaintext on 1883, so this defaults to false",
+          "DefaultValue": "false",
+          "Secret": false,
+          "Required": false
         }
       ]
     },

--- a/python/destinations/TDengine/README.md
+++ b/python/destinations/TDengine/README.md
@@ -20,6 +20,11 @@ Then either:
 
 The connector uses the following environment variables:
 
+These come from the shared **`tdengine-connection`** Variable Group (TDengine Connection), so the connection is defined once per environment rather than per deployment:
+
+- `TDENGINE_HOST`
+- `TDENGINE_TOKEN`
+- `TDENGINE_DATABASE`
 
 ### Required
 - **input**: This is the input topic.

--- a/python/destinations/TDengine/library.json
+++ b/python/destinations/TDengine/library.json
@@ -27,25 +27,36 @@
       "Required": true
     },
     {
-      "Name": "TDENGINE_HOST",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host address for the TDengine instance.",
-      "Required": true
-    },
-    {
-      "Name": "TDENGINE_TOKEN",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Authentication token to access TDengine. Either this or a username + password must be used.",
-      "Required": false
-    },
-    {
-      "Name": "TDENGINE_DATABASE",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "TDengine database name.",
-      "Required": true
+      "Name": "TDENGINE_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "TDengine host, token and database from a shared Variable Group.",
+      "VariableGroupId": "tdengine-connection",
+      "VariableGroupName": "TDengine Connection",
+      "VariableGroupDescription": "Shared TDengine host, token and database.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "TDENGINE_HOST",
+          "Description": "Host address of your TDengine instance, including the scheme and port",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "TDENGINE_TOKEN",
+          "Description": "Authentication token for your TDengine instance",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "TDENGINE_DATABASE",
+          "Description": "Database clients read from and write to",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "TDENGINE_SUPERTABLE",

--- a/python/destinations/big_query/README.md
+++ b/python/destinations/big_query/README.md
@@ -24,6 +24,13 @@ The connector uses the following environment variables:
 - **SERVICE_ACCOUNT_JSON**: The service account json string for the BigQuery GCP project. [Tutorial on how to create service account.](https://cloud.google.com/iam/docs/creating-managing-service-accounts#iam-service-accounts-create-console)
 - **MAX_QUEUE_SIZE**: Max queue size for the sink ingestion.
 
+These come from the shared **`bigquery-connection`** Variable Group (BigQuery Connection), so the connection is defined once per environment rather than per deployment:
+
+- `PROJECT_ID`
+- `DATASET_ID`
+- `DATASET_LOCATION`
+- `SERVICE_ACCOUNT_JSON`
+
 ## Known limitations 
 - BigQuery fails to immediately recognize new Schema changes such as adding a new field when streaming insert data.
 - BigQuery doesn't allow deleting data when streaming insert data.

--- a/python/destinations/big_query/library.json
+++ b/python/destinations/big_query/library.json
@@ -28,28 +28,43 @@
       "Required": true
     },
     {
-      "Name": "PROJECT_ID",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The BigQuery GCP Project ID",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "DATASET_ID",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The target BigQuery dataset ID",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "DATASET_LOCATION",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Location of BigQuery dataset",
-      "DefaultValue": "US",
-      "Required": true
+      "Name": "BIGQUERY_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "BigQuery project, dataset and service account from a shared Variable Group.",
+      "VariableGroupId": "bigquery-connection",
+      "VariableGroupName": "BigQuery Connection",
+      "VariableGroupDescription": "Shared BigQuery project, dataset and service account.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "PROJECT_ID",
+          "Description": "Your Google Cloud project id",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "DATASET_ID",
+          "Description": "The BigQuery dataset to write into",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "DATASET_LOCATION",
+          "Description": "The region the dataset lives in",
+          "DefaultValue": "US",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "SERVICE_ACCOUNT_JSON",
+          "Description": "Service account credentials as a JSON object",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "TABLE_NAME",
@@ -65,14 +80,6 @@
       "InputType": "FreeText",
       "Description": "Kafka consumer group.",
       "DefaultValue": "big-query-sink-v1",
-      "Required": true
-    },
-    {
-      "Name": "SERVICE_ACCOUNT_JSON",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "JSON string of the service account file for the BigQuery GCP project",
-      "DefaultValue": "",
       "Required": true
     },
     {

--- a/python/destinations/confluent_kafka/README.md
+++ b/python/destinations/confluent_kafka/README.md
@@ -19,9 +19,24 @@ The connector uses the following environment variables:
 
 - **input**: This is the Quix topic to listen to.
 - **kafka_topic**: The Confluent Kafka Topic you wish to read from.
-- **kafka_key**: Obtained from the Confluent Kafka portal.
-- **kafka_secret**: Obtained from the Confluent Kafka portal.
-- **kafka_broker_address**: Obtained from the Confluent Kafka portal.
+
+The cluster connection comes from the shared **`confluent-kafka-connection`** Variable Group,
+so this sink and the Confluent Kafka Source talk to the same cluster with the same API key:
+
+- **kafka_broker_address**: Bootstrap server address, obtained from the Confluent Kafka portal (Required: `True`)
+- **kafka_key**: API key, obtained from the Confluent Kafka portal (Required: `True`)
+- **kafka_secret**: API secret, obtained from the Confluent Kafka portal (Required: `True`)
+- **kafka_sasl_mechanism**: SASL mechanism. One of `PLAIN`, `SCRAM-SHA-256`,
+  `SCRAM-SHA-512`, `GSSAPI`, `OAUTHBEARER`, `AWS_MSK_IAM` (Default: `PLAIN`)
+- **kafka_ca_location**: Path to the SSL CA certificate file. Leave empty for the system
+  defaults
+
+This sink previously hard-coded `PLAIN` and ignored any CA path, so it could not reach a
+SCRAM-authenticated cluster that the Confluent Kafka Source could. It now reads both from
+the group, so the two ends authenticate the same way.
+
+`kafka_sasl_mechanism` is free text inside the group rather than a dropdown - the
+group schema has no options list. Valid values are given above.
 
 ## Contribute
 

--- a/python/destinations/confluent_kafka/library.json
+++ b/python/destinations/confluent_kafka/library.json
@@ -35,28 +35,50 @@
       "Required": true
     },
     {
-      "Name": "kafka_key",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Obtained from the Confluent Kafka portal",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "kafka_secret",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Obtained from the Confluent Kafka portal",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "kafka_broker_address",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Obtained from the Confluent Kafka portal",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "CONFLUENT_KAFKA_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Confluent Cloud broker address and API credentials from a shared Variable Group.",
+      "VariableGroupId": "confluent-kafka-connection",
+      "VariableGroupName": "Confluent Kafka Connection",
+      "VariableGroupDescription": "Shared Confluent Cloud bootstrap server and API key/secret.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "kafka_broker_address",
+          "Description": "Bootstrap server address, obtained from the Confluent Kafka portal",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "kafka_key",
+          "Description": "API key, obtained from the Confluent Kafka portal",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "kafka_secret",
+          "Description": "API secret, obtained from the Confluent Kafka portal",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "kafka_sasl_mechanism",
+          "Description": "SASL mechanism for authentication. One of: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI, OAUTHBEARER, AWS_MSK_IAM. Confluent Cloud API keys use PLAIN",
+          "DefaultValue": "PLAIN",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "kafka_ca_location",
+          "Description": "Path to the SSL CA certificate file. Leave empty to use the system's default CA certificates",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "consumer_group_name",

--- a/python/destinations/confluent_kafka/main.py
+++ b/python/destinations/confluent_kafka/main.py
@@ -11,7 +11,7 @@ load_dotenv()
 # SASL configuration
 # sasl.mechanism and ssl.ca.location come from the shared confluent-kafka-connection
 # Variable Group, so this sink and the Confluent Kafka Source authenticate the same way.
-# The PLAIN default preserves the behaviour of deployments made before the group existed.
+# PLAIN is the default because that is what Confluent Cloud API keys use.
 sasl_config = {
     'sasl.mechanism': os.getenv("kafka_sasl_mechanism", "PLAIN"),
     'security.protocol': 'SASL_SSL',

--- a/python/destinations/confluent_kafka/main.py
+++ b/python/destinations/confluent_kafka/main.py
@@ -9,11 +9,15 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # SASL configuration
+# sasl.mechanism and ssl.ca.location come from the shared confluent-kafka-connection
+# Variable Group, so this sink and the Confluent Kafka Source authenticate the same way.
+# The PLAIN default preserves the behaviour of deployments made before the group existed.
 sasl_config = {
-    'sasl.mechanism': 'PLAIN',
+    'sasl.mechanism': os.getenv("kafka_sasl_mechanism", "PLAIN"),
     'security.protocol': 'SASL_SSL',
     'sasl.username': os.getenv("kafka_key", ""),
-    'sasl.password': os.getenv("kafka_secret", "")
+    'sasl.password': os.getenv("kafka_secret", ""),
+    'ssl.ca.location': os.getenv("kafka_ca_location", "")
 }
 broker_address = os.getenv("kafka_broker_address", "")
 input_topic_name = os.getenv("input", "")

--- a/python/destinations/elasticsearch/README.md
+++ b/python/destinations/elasticsearch/README.md
@@ -20,6 +20,11 @@ Then either:
 The connector uses the following environment variables (which correspond to the 
 `ElasticsearchSink` parameter names):
 
+These come from the shared **`elasticsearch-connection`** Variable Group (Elasticsearch Connection), so the connection is defined once per environment rather than per deployment:
+
+- `ELASTICSEARCH_URL`
+- `ELASTICSEARCH_AUTHENTICATION_JSON`
+
 ### Required
 - `input`: The input Kafka topic name
 - `ELASTICSEARCH_URL`: Elasticsearch url

--- a/python/destinations/elasticsearch/library.json
+++ b/python/destinations/elasticsearch/library.json
@@ -28,24 +28,35 @@
       "Required": true
     },
     {
-      "Name": "ELASTICSEARCH_URL",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Elasticsearch url",
-      "Required": true
+      "Name": "ELASTICSEARCH_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Elasticsearch URL and authentication from a shared Variable Group.",
+      "VariableGroupId": "elasticsearch-connection",
+      "VariableGroupName": "Elasticsearch Connection",
+      "VariableGroupDescription": "Shared Elasticsearch URL and authentication.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "ELASTICSEARCH_URL",
+          "Description": "Base URL of your Elasticsearch instance, including the scheme and port",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "ELASTICSEARCH_AUTHENTICATION_JSON",
+          "Description": "Authentication settings as a JSON object, passed to the Elasticsearch client",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "ELASTICSEARCH_INDEX",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
       "Description": "Elasticsearch Index name",
-      "Required": true
-    },
-    {
-      "Name": "ELASTICSEARCH_AUTHENTICATION_JSON",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "A json-serializable object with Elasticsearch connection arguments",
       "Required": true
     },
     {

--- a/python/destinations/hivemq/README.md
+++ b/python/destinations/hivemq/README.md
@@ -25,10 +25,20 @@ The code sample uses the following environment variables:
 
 - **input**: Name of the input topic to listen to.
 - **mqtt_topic_root**: The root for messages in MQTT, this can be anything.
-- **mqtt_server**: The address of your MQTT server.
-- **mqtt_port**: The port of your MQTT server.
-- **mqtt_username**: Username of your MQTT user.
-- **mqtt_password**: Password for the MQTT user.
+
+The broker connection comes from the shared **`hivemq-connection`** Variable Group, so this
+sink and the HiveMQ Source connect to the same broker with the same credentials:
+
+- **mqtt_server**: Host address of your HiveMQ broker, without the protocol prefix (Required: `True`)
+- **mqtt_port**: Port of your HiveMQ broker (Default: `8883`, Required: `True`)
+- **mqtt_username**: Username of your HiveMQ user (Required: `False`)
+- **mqtt_password**: Password of your HiveMQ user (Required: `False`)
+- **mqtt_version**: MQTT protocol version. One of `3.1`, `3.1.1`, `5` (Default: `3.1.1`)
+- **mqtt_tls_enabled**: Enable TLS. One of `true`, `false` (Default: `true`, as HiveMQ
+  Cloud requires TLS on 8883)
+
+`mqtt_version` and `mqtt_tls_enabled` are free text inside the group rather than
+dropdowns - the group schema has no options list. Valid values are given above.
 
 ## Contribute
 

--- a/python/destinations/hivemq/library.json
+++ b/python/destinations/hivemq/library.json
@@ -35,71 +35,55 @@
       "Required": true
     },
     {
-      "Name": "mqtt_server",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The address of your MQTT server",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_port",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The port of your MQTT server",
-      "DefaultValue": "8883",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username of your MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_version",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "MQTT protocol version",
-      "DefaultValue": "3.1.1",
+      "Name": "HIVEMQ_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "HiveMQ broker address, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "hivemq-connection",
+      "VariableGroupName": "HiveMQ Connection",
+      "VariableGroupDescription": "Shared HiveMQ broker address, port and credentials.",
       "Required": true,
-      "options": [
+      "Variables": [
         {
-          "label": "3.1",
-          "value": "3.1"
+          "Key": "mqtt_server",
+          "Description": "Host address of your HiveMQ broker, without the protocol prefix",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "3.1.1",
-          "value": "3.1.1"
+          "Key": "mqtt_port",
+          "Description": "Port of your HiveMQ broker",
+          "DefaultValue": "8883",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "5",
-          "value": "5"
-        }
-      ]
-    },
-    {
-      "Name": "mqtt_tls_enabled",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "Enable TLS for MQTT connection",
-      "DefaultValue": "true",
-      "Required": false,
-      "options": [
-        {
-          "label": "true",
-          "value": "true"
+          "Key": "mqtt_username",
+          "Description": "Username of your HiveMQ user",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
         },
         {
-          "label": "false",
-          "value": "false"
+          "Key": "mqtt_password",
+          "Description": "Password of your HiveMQ user",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_version",
+          "Description": "MQTT protocol version. One of: 3.1, 3.1.1, 5",
+          "DefaultValue": "3.1.1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_tls_enabled",
+          "Description": "Enable TLS for the broker connection. One of: true, false. HiveMQ Cloud requires TLS on 8883",
+          "DefaultValue": "true",
+          "Secret": false,
+          "Required": false
         }
       ]
     },

--- a/python/destinations/influxdb_1/README.md
+++ b/python/destinations/influxdb_1/README.md
@@ -25,9 +25,7 @@ The connector uses the following environment variables:
 - **input**: Quix input topic
 
 The connection comes from the shared **`influxdb1-config`** Variable Group, so this sink
-and the bundled InfluxDB v1 server agree. These were renamed from `INFLUXDB_HOST` /
-`INFLUXDB_PORT` / `INFLUXDB_USERNAME` / `INFLUXDB_PASSWORD` / `INFLUXDB_DATABASE`, which
-still work for existing deployments:
+and the bundled InfluxDB v1 server agree:
 
 - **INFLUXDB1_HOST**: Host address of the InfluxDB v1 instance, including the scheme (Default: `http://influxdb`)
 - **INFLUXDB1_PORT**: Port of the InfluxDB v1 instance (Default: `80`)

--- a/python/destinations/influxdb_1/README.md
+++ b/python/destinations/influxdb_1/README.md
@@ -23,14 +23,19 @@ The connector uses the following environment variables:
 
 ### Required
 - **input**: Quix input topic
-- **INFLUXDB_HOST**: Host address for the InfluxDB instance.
-- **INFLUXDB_PORT**: Port for the InfluxDB instance.
-- **INFLUXDB_USERNAME**: Username for the InfluxDB instance.
-- **INFLUXDB_PASSWORD**: Password for the InfluxDB instance.
+
+The connection comes from the shared **`influxdb1-config`** Variable Group, so this sink
+and the bundled InfluxDB v1 server agree. These were renamed from `INFLUXDB_HOST` /
+`INFLUXDB_PORT` / `INFLUXDB_USERNAME` / `INFLUXDB_PASSWORD` / `INFLUXDB_DATABASE`, which
+still work for existing deployments:
+
+- **INFLUXDB1_HOST**: Host address of the InfluxDB v1 instance, including the scheme (Default: `http://influxdb`)
+- **INFLUXDB1_PORT**: Port of the InfluxDB v1 instance (Default: `80`)
+- **INFLUXDB1_USERNAME**: Username for the InfluxDB instance (Default: `admin`)
+- **INFLUXDB1_PASSWORD**: Password for the InfluxDB instance
+- **INFLUXDB1_DATABASE**: Database name where data should be stored (Default: `quix`)
 
 ### Optional
-- **INFLUXDB_DATABASE**: Database name in InfluxDB where data should be stored. 
-  Default: `quix`
 - **INFLUXDB_TAG_KEYS**: A comma-separated list of column names (based on message value) to be used as tags when writing data to InfluxDB.
   Can optionally replace with a callable in the template directly.
 - **INFLUXDB_FIELD_KEYS**: A comma-separated list of column names (based on message value) to be used as fields when writing data to InfluxDB.

--- a/python/destinations/influxdb_1/library.json
+++ b/python/destinations/influxdb_1/library.json
@@ -28,32 +28,50 @@
       "Required": true
     },
     {
-      "Name": "INFLUXDB_HOST",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host address for the InfluxDB instance (formatted as https://<host>).",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_PORT",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Port for the InfluxDB instance.",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username for the InfluxDB instance.",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the InfluxDB instance.",
-      "Required": true
+      "Name": "INFLUXDB1_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "InfluxDB v1 connection details and admin credentials from a shared Variable Group.",
+      "VariableGroupId": "influxdb1-config",
+      "VariableGroupName": "InfluxDB v1 config",
+      "VariableGroupDescription": "Shared InfluxDB v1 connection details and admin credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "INFLUXDB1_HOST",
+          "Description": "Host address of the InfluxDB v1 instance, including the http:// scheme",
+          "DefaultValue": "http://influxdb",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_PORT",
+          "Description": "Port of the InfluxDB v1 instance (80 for the bundled server on the internal Quix network)",
+          "DefaultValue": "80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_DATABASE",
+          "Description": "Database clients read and write, and the database the server is initialised with",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_USERNAME",
+          "Description": "Admin username the server is initialised with, and that clients authenticate as",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB1_PASSWORD",
+          "Description": "Admin password the server is initialised with, and that clients authenticate with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "INFLUXDB_MEASUREMENT_NAME",
@@ -62,14 +80,6 @@
       "Description": "The InfluxDB measurement to write data to. Can optionally replace with a callable in the template directly.",
       "DefaultValue": "default",
       "Required": false
-    },
-    {
-      "Name": "INFLUXDB_DATABASE",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Database name in InfluxDB where data should be stored.",
-      "DefaultValue": "quix",
-      "Required": true
     },
     {
       "Name": "INFLUXDB_TAG_KEYS",

--- a/python/destinations/influxdb_1/main.py
+++ b/python/destinations/influxdb_1/main.py
@@ -22,18 +22,6 @@ def _as_iterable(env_var) -> list[str]:
     return keys.split(",") if (keys := os.environ.get(env_var)) else []
 
 
-def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
-    """
-    Read a connection env var by the name the shared influxdb1-config Variable Group injects,
-    falling back to the legacy INFLUXDB_* name so deployments created before the rename
-    keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name) or default
-    if value is None:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 # Potential Callables - can manually edit these to instead use your own callables.
 # --Required--
 measurement_name: MeasurementSetter = os.getenv("INFLUXDB_MEASUREMENT_NAME", "default")
@@ -53,14 +41,14 @@ def on_connect_failure(err):
 
 
 influxdb_v1_sink = InfluxDB1Sink(
-    host=conn_var("INFLUXDB1_HOST", "INFLUXDB_HOST"),
-    port=int(conn_var("INFLUXDB1_PORT", "INFLUXDB_PORT")),
-    username=conn_var("INFLUXDB1_USERNAME", "INFLUXDB_USERNAME"),
-    password=conn_var("INFLUXDB1_PASSWORD", "INFLUXDB_PASSWORD"),
+    host=os.environ["INFLUXDB1_HOST"],
+    port=int(os.environ["INFLUXDB1_PORT"]),
+    username=os.environ["INFLUXDB1_USERNAME"],
+    password=os.environ["INFLUXDB1_PASSWORD"],
     tags_keys=tag_keys,
     fields_keys=field_keys,
     time_setter=time_setter,
-    database=conn_var("INFLUXDB1_DATABASE", "INFLUXDB_DATABASE", "quix"),
+    database=os.getenv("INFLUXDB1_DATABASE", "quix"),
     measurement=measurement_name,
     on_client_connect_success=on_connect_success,
     on_client_connect_failure=on_connect_failure,

--- a/python/destinations/influxdb_1/main.py
+++ b/python/destinations/influxdb_1/main.py
@@ -22,6 +22,18 @@ def _as_iterable(env_var) -> list[str]:
     return keys.split(",") if (keys := os.environ.get(env_var)) else []
 
 
+def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
+    """
+    Read a connection env var by the name the shared influxdb1-config Variable Group injects,
+    falling back to the legacy INFLUXDB_* name so deployments created before the rename
+    keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name) or default
+    if value is None:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
 # Potential Callables - can manually edit these to instead use your own callables.
 # --Required--
 measurement_name: MeasurementSetter = os.getenv("INFLUXDB_MEASUREMENT_NAME", "default")
@@ -41,14 +53,14 @@ def on_connect_failure(err):
 
 
 influxdb_v1_sink = InfluxDB1Sink(
-    host=os.environ["INFLUXDB_HOST"],
-    port=int(os.environ["INFLUXDB_PORT"]),
-    username=os.environ["INFLUXDB_USERNAME"],
-    password=os.environ["INFLUXDB_PASSWORD"],
+    host=conn_var("INFLUXDB1_HOST", "INFLUXDB_HOST"),
+    port=int(conn_var("INFLUXDB1_PORT", "INFLUXDB_PORT")),
+    username=conn_var("INFLUXDB1_USERNAME", "INFLUXDB_USERNAME"),
+    password=conn_var("INFLUXDB1_PASSWORD", "INFLUXDB_PASSWORD"),
     tags_keys=tag_keys,
     fields_keys=field_keys,
     time_setter=time_setter,
-    database=os.getenv("INFLUXDB_DATABASE", "quix"),
+    database=conn_var("INFLUXDB1_DATABASE", "INFLUXDB_DATABASE", "quix"),
     measurement=measurement_name,
     on_client_connect_success=on_connect_success,
     on_client_connect_failure=on_connect_failure,

--- a/python/destinations/influxdb_3/library.json
+++ b/python/destinations/influxdb_3/library.json
@@ -33,7 +33,7 @@
       "Description": "Shared InfluxDB v3 connection details and admin token (used by this server and by every client that reads/writes it)",
       "VariableGroupId": "influxdb3-config",
       "VariableGroupName": "InfluxDB v3 config",
-      "VariableGroupDescription": "Shared InfluxDB v3 connection details and admin token (used by this server and by every client that reads/writes it)",
+      "VariableGroupDescription": "Shared InfluxDB v3 connection details and admin token, used by the server and all its clients",
       "Required": true,
       "Variables": [
         {

--- a/python/destinations/mongodb/README.md
+++ b/python/destinations/mongodb/README.md
@@ -8,15 +8,15 @@ MongoDB database using the [Quix Streams MongoDB sink](https://quix.io/docs/quix
 
 This deployment will work seamlessly with a [Quix Cloud MongoDB service](https://github.com/quixio/quix-samples/tree/main/docker/mongodb).
 
-Simply provide the following arguments to this connector, 
-where `username` and `password` are are the credentials used when 
-creating the **Quix Cloud MongoDB service**: 
+Assign the same `mongodb-connection` variable group to this connector and to the
+**Quix Cloud MongoDB service**, and both ends use the same connection - no need to copy
+the values by hand:
 
 ```shell
-MONGODB_USERNAME="<YOUR USERNAME>"  # (default: "admin")
-MONGODB_PASSWORD="<YOUR PASSWORD>"
-MONGODB_HOST="mongodb"
-MONGODB_PORT="27017"
+MONGO_HOST="mongodb"      # the internal service name
+MONGO_PORT="27017"
+MONGO_USER="admin"
+MONGO_PASSWORD="<YOUR PASSWORD>"
 ```
 ## How to run
 
@@ -36,9 +36,16 @@ The connector uses the following environment variables (which correspond to the
 
 ### Required
 - `input`: The input Kafka topic name
-- `MONGODB_URL`: MongoDB url; most commonly `mongodb://username:password@host:port`
-- `MONGODB_DB`: MongoDB database name
-- `MONGODB_COLLECTION`: MongoDB collection name
+- `MONGO_DATABASE`: MongoDB database name
+- `MONGO_COLLECTION`: MongoDB collection name
+
+The connection itself comes from the shared **`mongodb-connection`** Variable Group, so
+this sink, the bundled MongoDB service and any other client agree on one connection:
+
+- `MONGO_HOST`: MongoDB host name (Default: `mongodb`)
+- `MONGO_PORT`: MongoDB host port (Default: `27017`)
+- `MONGO_USER`: MongoDB username (Default: `admin`)
+- `MONGO_PASSWORD`: MongoDB password
 
 ### Optional
 Unless explicitly defined, these are set to the [`MongoDBSink` defaults](https://quix.io/docs/quix-streams/connectors/sinks/mongodb-sink.html#configuration-options).

--- a/python/destinations/mongodb/main.py
+++ b/python/destinations/mongodb/main.py
@@ -40,17 +40,6 @@ def _as_bool(value: Union[str, bool]) -> bool:
     return value.lower() == "true"
 
 
-def conn_var(new_name: str, legacy_name: str, required: bool = True) -> Optional[str]:
-    """
-    Read a Mongo connection env var by its aligned MONGO_* name, falling back to the
-    legacy MONGODB_* name so deployments created before the rename keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name)
-    if required and not value:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 def replace_query_refs(data):
     """
     Replaces query values like "__value.x.y.z" with a corresponding callable on a BatchItem.
@@ -111,13 +100,13 @@ input_topic = app.topic(os.environ["input"])
 kwargs_defaults = get_kwargs_defaults()
 mongodb_sink = MongoDBSink(
     # required settings
-    host=conn_var("MONGO_HOST", "MONGODB_HOST"),
-    username=conn_var("MONGO_USER", "MONGODB_USERNAME"),
-    password=conn_var("MONGO_PASSWORD", "MONGODB_PASSWORD"),
-    db=conn_var("MONGO_DATABASE", "MONGODB_DB"),
-    collection=conn_var("MONGO_COLLECTION", "MONGODB_COLLECTION"),
+    host=os.environ["MONGO_HOST"],
+    username=os.environ["MONGO_USER"],
+    password=os.environ["MONGO_PASSWORD"],
+    db=os.environ["MONGO_DATABASE"],
+    collection=os.environ["MONGO_COLLECTION"],
     # optional settings (have defaults)
-    port=int(port) if (port := conn_var("MONGO_PORT", "MONGODB_PORT", required=False)) else kwargs_defaults["port"],
+    port=int(port) if (port := os.getenv("MONGO_PORT")) else kwargs_defaults["port"],
     update_method=os.getenv("MONGODB_UPDATE_METHOD", kwargs_defaults["update_method"]),
     upsert=_as_bool(os.getenv("MONGODB_UPSERT", kwargs_defaults["upsert"])),
     document_matcher=document_matcher_env_parser() or kwargs_defaults["document_matcher"],

--- a/python/destinations/postgres/README.md
+++ b/python/destinations/postgres/README.md
@@ -27,8 +27,7 @@ this sink, the Postgres CDC Source and the bundled PostgreSQL server all agree:
 
 - **POSTGRES_HOST**: Host address of the PostgreSQL instance (Default: `postgresql`)
 - **POSTGRES_PORT**: Port of the PostgreSQL instance (Default: `80`)
-- **POSTGRES_DB**: Database name where data should be stored (Default: `quix`).
-  Renamed from `POSTGRES_DBNAME`, which still works for existing deployments.
+- **POSTGRES_DB**: Database name where data should be stored (Default: `quix`)
 - **POSTGRES_USER**: Username for the PostgreSQL database (Default: `admin`)
 - **POSTGRES_PASSWORD**: Password for the PostgreSQL database
 

--- a/python/destinations/postgres/README.md
+++ b/python/destinations/postgres/README.md
@@ -19,13 +19,18 @@ The connector uses the following environment variables:
 
 ### Required
 - **input**: The input kafka topic.
-- **POSTGRES_HOST**: Host address for the PostgreSQL instance.
-- **POSTGRES_PORT**: Port number for the PostgreSQL instance.
-- **POSTGRES_DBNAME**: Database name in PostgreSQL where data should be stored.
-- **POSTGRES_USER**: Username for the PostgreSQL database.
-- **POSTGRES_PASSWORD**: Password for the PostgreSQL database.
 - **POSTGRES_TABLE**: The PostgreSQL table where data will be stored. If the table does not exist, it will be created automatically.  
   Default: `default_table`
+
+The connection itself comes from the shared **`postgres-connection`** Variable Group, so
+this sink, the Postgres CDC Source and the bundled PostgreSQL server all agree:
+
+- **POSTGRES_HOST**: Host address of the PostgreSQL instance (Default: `postgresql`)
+- **POSTGRES_PORT**: Port of the PostgreSQL instance (Default: `80`)
+- **POSTGRES_DB**: Database name where data should be stored (Default: `quix`).
+  Renamed from `POSTGRES_DBNAME`, which still works for existing deployments.
+- **POSTGRES_USER**: Username for the PostgreSQL database (Default: `admin`)
+- **POSTGRES_PASSWORD**: Password for the PostgreSQL database
 
 ### Optional
 - **POSTGRES_SCHEMA**: The schema name. Schemas are a way of organizing tables and not related to the table data, referenced as `<schema_name>.<table_name>`.  

--- a/python/destinations/postgres/library.json
+++ b/python/destinations/postgres/library.json
@@ -28,43 +28,50 @@
       "Required": true
     },
     {
-      "Name": "POSTGRES_HOST",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host address for the PostgreSQL instance.",
-      "DefaultValue": "postgresql",
-      "Required": true
-    },
-    {
-      "Name": "POSTGRES_PORT",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Port number for the PostgreSQL instance.",
-      "DefaultValue": "80",
-      "Required": true
-    },
-    {
-      "Name": "POSTGRES_DBNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Database name in PostgreSQL where data should be stored.",
-      "DefaultValue": "quix",
-      "Required": true
-    },
-    {
-      "Name": "POSTGRES_USER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username for the PostgreSQL database.",
-      "DefaultValue": "admin",
-      "Required": true
-    },
-    {
-      "Name": "POSTGRES_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the PostgreSQL database.",
-      "Required": true
+      "Name": "POSTGRES_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "PostgreSQL host, port, database and credentials from a shared Variable Group.",
+      "VariableGroupId": "postgres-connection",
+      "VariableGroupName": "PostgreSQL Connection",
+      "VariableGroupDescription": "Shared PostgreSQL host, port, database and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "POSTGRES_HOST",
+          "Description": "Host address of the PostgreSQL instance",
+          "DefaultValue": "postgresql",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_PORT",
+          "Description": "Port of the PostgreSQL instance (80 for the bundled server on the internal Quix network)",
+          "DefaultValue": "80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_DB",
+          "Description": "Database name to connect to, and to initialise the server with",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_USER",
+          "Description": "Username for the PostgreSQL database",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_PASSWORD",
+          "Description": "Password for the PostgreSQL database",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "POSTGRES_TABLE",

--- a/python/destinations/postgres/main.py
+++ b/python/destinations/postgres/main.py
@@ -18,18 +18,6 @@ def _as_iterable(env_var) -> list[str]:
     return keys.split(",") if (keys := os.environ.get(env_var)) else []
 
 
-def conn_var(new_name: str, legacy_name: str) -> str:
-    """
-    Read a connection env var by the name the shared postgres-connection Variable Group
-    injects, falling back to the legacy name so deployments created before the rename
-    keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name)
-    if not value:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 # Potential Callables - can manually edit these to instead use your own callables.
 # --Required--
 table_name: TableName = os.getenv("POSTGRES_TABLE", "default_table")
@@ -50,7 +38,7 @@ def on_connect_failure(err):
 postgres_sink = PostgreSQLSink(
     host=os.environ["POSTGRES_HOST"],
     port=int(os.environ["POSTGRES_PORT"]),
-    dbname=conn_var("POSTGRES_DB", "POSTGRES_DBNAME"),
+    dbname=os.environ["POSTGRES_DB"],
     user=os.environ["POSTGRES_USER"],
     password=os.environ["POSTGRES_PASSWORD"],
     table_name=table_name,

--- a/python/destinations/postgres/main.py
+++ b/python/destinations/postgres/main.py
@@ -18,6 +18,18 @@ def _as_iterable(env_var) -> list[str]:
     return keys.split(",") if (keys := os.environ.get(env_var)) else []
 
 
+def conn_var(new_name: str, legacy_name: str) -> str:
+    """
+    Read a connection env var by the name the shared postgres-connection Variable Group
+    injects, falling back to the legacy name so deployments created before the rename
+    keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name)
+    if not value:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
 # Potential Callables - can manually edit these to instead use your own callables.
 # --Required--
 table_name: TableName = os.getenv("POSTGRES_TABLE", "default_table")
@@ -38,7 +50,7 @@ def on_connect_failure(err):
 postgres_sink = PostgreSQLSink(
     host=os.environ["POSTGRES_HOST"],
     port=int(os.environ["POSTGRES_PORT"]),
-    dbname=os.environ["POSTGRES_DBNAME"],
+    dbname=conn_var("POSTGRES_DB", "POSTGRES_DBNAME"),
     user=os.environ["POSTGRES_USER"],
     password=os.environ["POSTGRES_PASSWORD"],
     table_name=table_name,

--- a/python/destinations/redis_dest/README.md
+++ b/python/destinations/redis_dest/README.md
@@ -23,11 +23,15 @@ Then either:
 The connector uses the following environment variables:
 
 - **input**: This is the input topic (Default: `input`, Required: `True`)
-- **redis_host**: Host address for the Redis instance (Required: `True`)
-- **redis_port**: Port for the Redis instance (Default: `6379`, Required: `True`)
-- **redis_password**: Password for the Redis instance (Default: `None`, Required: `False`)
-- **redis_username**: Username for the Redis instance (Default: `None`, Required: `False`)
 - **redis_key_prefix**: The prefix for the key to store data under.
+
+The Redis connection comes from the shared **`redis-connection`** Variable Group, so this
+sink, the Redis Source and anything else pointing at the same instance stay in sync:
+
+- **redis_host**: Host address of your Redis instance (Required: `True`)
+- **redis_port**: Port of your Redis instance (Default: `6379`, Required: `True`)
+- **redis_username**: Username for your Redis instance, if it requires one (Required: `False`)
+- **redis_password**: Password for your Redis instance, if it requires one (Required: `False`)
 
 ## Requirements / Prerequisites
 

--- a/python/destinations/redis_dest/library.json
+++ b/python/destinations/redis_dest/library.json
@@ -28,35 +28,43 @@
       "Required": true
     },
     {
-      "Name": "redis_host",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host address for the Redis instance",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "redis_port",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Port for the Redis instance",
-      "DefaultValue": "6379",
-      "Required": true
-    },
-    {
-      "Name": "redis_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the Redis instance",
-      "Required": false
-    },
-    {
-      "Name": "redis_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username for the Redis instance",
-      "DefaultValue": "",
-      "Required": false
+      "Name": "REDIS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Redis host, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "redis-connection",
+      "VariableGroupName": "Redis Connection",
+      "VariableGroupDescription": "Shared Redis host, port and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "redis_host",
+          "Description": "Host address of your Redis instance",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "redis_port",
+          "Description": "Port of your Redis instance",
+          "DefaultValue": "6379",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "redis_username",
+          "Description": "Username for your Redis instance, if it requires one",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "redis_password",
+          "Description": "Password for your Redis instance, if it requires one",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "redis_key_prefix",

--- a/python/destinations/s3-file/README.md
+++ b/python/destinations/s3-file/README.md
@@ -28,7 +28,6 @@ AWS connector in the pipeline uses one set of credentials:
 - `AWS_ACCESS_KEY_ID`: Your AWS access key ID.
 - `AWS_SECRET_ACCESS_KEY`: Your AWS secret access key.
 - `AWS_REGION`: The region of your S3 bucket (Default: `us-east-1`).
-  Renamed from `AWS_REGION_NAME`, which still works for existing deployments.
 
 ### Optional
 Unless explicitly defined, these are optional, or generally set to the [`S3FileSink`](https://quix.io/docs/quix-streams/connectors/sinks/amazon-s3-sink.html) defaults.

--- a/python/destinations/s3-file/README.md
+++ b/python/destinations/s3-file/README.md
@@ -21,10 +21,14 @@ The connector uses the following environment variables (which generally correspo
 ### Required
 - `input`: The input Kafka topic
 - `S3_BUCKET`: The S3 bucket to use.
-- `AWS_ENDPOINT_URL`: The URL to your S3 instance.
-- `AWS_REGION_NAME`: The region of your S3 bucket.
-- `AWS_SECRET_ACCESS_KEY`: Your AWS secret.
-- `AWS_ACCESS_KEY_ID`: Your AWS Access Key.
+
+Credentials and region come from the shared **`aws-connection`** Variable Group, so every
+AWS connector in the pipeline uses one set of credentials:
+
+- `AWS_ACCESS_KEY_ID`: Your AWS access key ID.
+- `AWS_SECRET_ACCESS_KEY`: Your AWS secret access key.
+- `AWS_REGION`: The region of your S3 bucket (Default: `us-east-1`).
+  Renamed from `AWS_REGION_NAME`, which still works for existing deployments.
 
 ### Optional
 Unless explicitly defined, these are optional, or generally set to the [`S3FileSink`](https://quix.io/docs/quix-streams/connectors/sinks/amazon-s3-sink.html) defaults.

--- a/python/destinations/s3-file/library.json
+++ b/python/destinations/s3-file/library.json
@@ -43,25 +43,50 @@
       "Required": false
     },
     {
-      "Name": "AWS_REGION_NAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The region of your S3 bucket.",
-      "Required": true
-    },
-    {
-      "Name": "AWS_SECRET_ACCESS_KEY",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Your AWS secret.",
-      "Required": true
-    },
-    {
-      "Name": "AWS_ACCESS_KEY_ID",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Your AWS Access Key.",
-      "Required": true
+      "Name": "AWS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "AWS credentials and region from a shared Variable Group.",
+      "VariableGroupId": "aws-connection",
+      "VariableGroupName": "AWS Connection",
+      "VariableGroupDescription": "Shared AWS credentials, region and optional S3-compatible endpoint.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "AWS_ACCESS_KEY_ID",
+          "Description": "Your AWS access key ID",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SECRET_ACCESS_KEY",
+          "Description": "Your AWS secret access key",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_REGION",
+          "Description": "The AWS region your resources live in",
+          "DefaultValue": "us-east-1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SESSION_TOKEN",
+          "Description": "AWS session token, for temporary credentials only",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "AWS_ENDPOINT_URL",
+          "Description": "Custom endpoint for S3-compatible storage such as MinIO. Leave empty for AWS",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "FILE_FORMAT",

--- a/python/destinations/s3-file/main.py
+++ b/python/destinations/s3-file/main.py
@@ -25,6 +25,18 @@ def on_connect_success():
     print("CONNECTED!")
 
 
+def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
+    """
+    Read a connection env var by the name the shared aws-connection Variable Group
+    injects, falling back to the legacy name so deployments created before the rename
+    keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name) or default
+    if value is None:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
 def on_connect_failure(err):
     print(f"ERROR! Failed to connect to S3: {err}")
     raise err
@@ -35,7 +47,7 @@ s3_file_sink = S3FileSink(
     directory=os.getenv("S3_BUCKET_DIRECTORY", ""),
     aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-    region_name=os.environ["AWS_REGION_NAME"],
+    region_name=conn_var("AWS_REGION", "AWS_REGION_NAME"),
     format=get_file_format(),
     on_client_connect_success=on_connect_success,
     on_client_connect_failure=on_connect_failure,

--- a/python/destinations/s3-file/main.py
+++ b/python/destinations/s3-file/main.py
@@ -25,18 +25,6 @@ def on_connect_success():
     print("CONNECTED!")
 
 
-def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
-    """
-    Read a connection env var by the name the shared aws-connection Variable Group
-    injects, falling back to the legacy name so deployments created before the rename
-    keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name) or default
-    if value is None:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 def on_connect_failure(err):
     print(f"ERROR! Failed to connect to S3: {err}")
     raise err
@@ -47,7 +35,7 @@ s3_file_sink = S3FileSink(
     directory=os.getenv("S3_BUCKET_DIRECTORY", ""),
     aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-    region_name=conn_var("AWS_REGION", "AWS_REGION_NAME"),
+    region_name=os.environ["AWS_REGION"],
     format=get_file_format(),
     on_client_connect_success=on_connect_success,
     on_client_connect_failure=on_connect_failure,

--- a/python/destinations/s3-iceberg-destination/README.md
+++ b/python/destinations/s3-iceberg-destination/README.md
@@ -19,10 +19,15 @@ The connector uses the following environment variables:
 
 - **input**: This is the input topic (Default: `input`, Required: `True`)
 - **AWS_S3_URI**: The URI or URL to your S3 bucket (Required: `True`)
-- **AWS_SECRET_ACCESS_KEY**: Your AWS secret (Required: `True`)
-- **AWS_ACCESS_KEY_ID**: Your AWS Access Key (Required: `True`)
-- **AWS_REGION**: Your AWS S3 bucket region (Required: `True`)
 - **table_name**: The table to publish data to (Required: `True`)
+
+Credentials and region come from the shared **`aws-connection`** Variable Group, so every
+AWS connector in the pipeline uses one set of credentials:
+
+- **AWS_ACCESS_KEY_ID**: Your AWS access key ID
+- **AWS_SECRET_ACCESS_KEY**: Your AWS secret access key
+- **AWS_REGION**: Your AWS S3 bucket region (Default: `us-east-1`)
+- **AWS_SESSION_TOKEN**: AWS session token, for temporary credentials only (optional)
 
 ## Requirements / Prerequisites
 

--- a/python/destinations/s3-iceberg-destination/library.json
+++ b/python/destinations/s3-iceberg-destination/library.json
@@ -36,28 +36,50 @@
       "Required": true
     },
     {
-      "Name": "AWS_REGION",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The region of your S3 bucket",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "AWS_SECRET_ACCESS_KEY",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Your AWS secret",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "AWS_ACCESS_KEY_ID",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Your AWS Access Key",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "AWS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "AWS credentials and region from a shared Variable Group.",
+      "VariableGroupId": "aws-connection",
+      "VariableGroupName": "AWS Connection",
+      "VariableGroupDescription": "Shared AWS credentials, region and optional S3-compatible endpoint.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "AWS_ACCESS_KEY_ID",
+          "Description": "Your AWS access key ID",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SECRET_ACCESS_KEY",
+          "Description": "Your AWS secret access key",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_REGION",
+          "Description": "The AWS region your resources live in",
+          "DefaultValue": "us-east-1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SESSION_TOKEN",
+          "Description": "AWS session token, for temporary credentials only",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "AWS_ENDPOINT_URL",
+          "Description": "Custom endpoint for S3-compatible storage such as MinIO. Leave empty for AWS",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "table_name",
@@ -66,14 +88,6 @@
       "Description": "The table to publish data to",
       "DefaultValue": "",
       "Required": true
-    },
-    {
-      "Name": "AWS_SESSION_TOKEN",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "AWS session token (optional, for temporary credentials)",
-      "DefaultValue": "",
-      "Required": false
     }
   ],
   "DeploySettings": {

--- a/python/destinations/s3-iceberg-destination/main.py
+++ b/python/destinations/s3-iceberg-destination/main.py
@@ -28,7 +28,8 @@ iceberg_sink = IcebergSink(
         aws_region=os.environ["AWS_REGION"],
         aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
         aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-        aws_session_token=os.getenv("AWS_SESSION_TOKEN")
+        # `or None` so a blank value from the Variable Group is not passed as ""
+        aws_session_token=os.getenv("AWS_SESSION_TOKEN") or None
     ),
     on_client_connect_success=on_connect_success,
     on_client_connect_failure=on_connect_failure,

--- a/python/destinations/slack_notifications/README.md
+++ b/python/destinations/slack_notifications/README.md
@@ -20,6 +20,12 @@ The connector uses the following environment variables:
 - **input**: Name of the input topic to listen to.
 - **webhook_url**: The webhook url to send notifications to
 
+These come from the shared **`slack-webhook`** Variable Group (Slack Webhook), so the connection is defined once per environment rather than per deployment:
+
+- `webhook_url`
+
+`webhook_url` is now marked secret inside the group - a Slack incoming webhook URL is a credential, and it used to be stored in plain text.
+
 ## Requirements / Prerequisites
 
 You'll need to have access to Slack and be able to set up a webhook here: https://api.slack.com/apps

--- a/python/destinations/slack_notifications/library.json
+++ b/python/destinations/slack_notifications/library.json
@@ -29,11 +29,22 @@
       "Required": true
     },
     {
-      "Name": "webhook_url",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The webhook url to send notifications to",
-      "Required": true
+      "Name": "SLACK_WEBHOOK",
+      "InputType": "VariableGroup",
+      "Description": "Slack incoming webhook URL from a shared Variable Group.",
+      "VariableGroupId": "slack-webhook",
+      "VariableGroupName": "Slack Webhook",
+      "VariableGroupDescription": "Shared Slack incoming webhook URL.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "webhook_url",
+          "Description": "Slack incoming webhook URL to post messages to",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "consumer_group_name",

--- a/python/destinations/websocket/README.md
+++ b/python/destinations/websocket/README.md
@@ -20,8 +20,10 @@ The service requires the following environment variables:
 
 Authentication is required and is easy to configure. Provide a user name and password in the above environment variables, these will be used to authenticate users.
 
-If deploying to Quix Cloud you will need to create secrets for the username and password.
-See the [docs](https://quix.io/docs/deploy/secrets-management.html) for more information on how to do this.
+`WS_USERNAME` and `WS_PASSWORD` come from the shared **`websocket-connection`** Variable
+Group, so the credentials are defined once per environment rather than per deployment, and
+both are stored as secrets. Assign the group to this deployment (or your
+project/environment) - there is no longer a separate workspace secret to create.
 
 ## Connecting
 

--- a/python/destinations/websocket/library.json
+++ b/python/destinations/websocket/library.json
@@ -27,20 +27,29 @@
       "Required": true
     },
     {
-      "Name": "WS_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Websocket username",
-      "DefaultValue": "websocket_username",
-      "Required": true
-    },
-    {
-      "Name": "WS_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Websocket password",
-      "DefaultValue": "websocket_password",
-      "Required": true
+      "Name": "WEBSOCKET_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Websocket credentials from a shared Variable Group.",
+      "VariableGroupId": "websocket-connection",
+      "VariableGroupName": "Websocket Connection",
+      "VariableGroupDescription": "Shared websocket credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "WS_USERNAME",
+          "Description": "Username for the websocket endpoint",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "WS_PASSWORD",
+          "Description": "Password for the websocket endpoint",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
   ],
   "DeploySettings": {

--- a/python/others/jupyterlab/README.md
+++ b/python/others/jupyterlab/README.md
@@ -3,11 +3,18 @@
 This sample demonstrates how to deploy a JupyterLab instance so you can run
 Jupyter notebooks from the platform.
 
+## Configuration
+
+The UI password comes from the shared **`jupyter-auth`** Variable Group, so it is defined
+once per environment rather than per deployment:
+
+- `JUPYTER_PASSWORD` - password required to open the JupyterLab UI, secret.
+
 ## How to Run
 
 1. Log in or sign up at [Quix](https://portal.cloud.quix.io/signup?utm_campaign=github) and navigate to the Code Samples section.
-2. Click **Deploy** to launch a pre-built container.
-3. Fill in the required environment variables for your JupyterLab instance.
+2. Assign the `jupyter-auth` variable group, setting `JUPYTER_PASSWORD`.
+3. Click **Deploy** to launch a pre-built container.
 4. Enable state, otherwise changes will be lost on restart. Please note, the necessary storage type may not be supported on all Quix Platforms.
 
 For more configuration options and details, refer to [Mongo Docker Hub](https://hub.docker.com/_/mongo).

--- a/python/others/jupyterlab/library.json
+++ b/python/others/jupyterlab/library.json
@@ -37,11 +37,22 @@
   },
   "Variables": [
     {
-      "Name": "JUPYTER_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The allowed password for connecting to JupyterLab",
-      "Required": true
+      "Name": "JUPYTER_AUTH",
+      "InputType": "VariableGroup",
+      "Description": "JupyterLab password from a shared Variable Group.",
+      "VariableGroupId": "jupyter-auth",
+      "VariableGroupName": "Jupyter Auth",
+      "VariableGroupDescription": "Shared JupyterLab password.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "JUPYTER_PASSWORD",
+          "Description": "Password required to open the JupyterLab UI",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
   ]
 }

--- a/python/others/marimo/README.md
+++ b/python/others/marimo/README.md
@@ -18,6 +18,12 @@ This sample demonstrates how to deploy a [Marimo](https://marimo.io/) notebook i
 | `MARIMO_PASSWORD` | Optional password protection for standalone mode | (none) |
 | `QUIX_PLUGIN_MODE` | Set to `true` to enable Quix plugin mode with nginx auth proxy | `false` |
 
+These come from the shared **`anthropic-api`** Variable Group (Anthropic API), so the connection is defined once per environment rather than per deployment:
+
+- `ANTHROPIC_API_KEY`
+
+The key is optional, so the group reference is optional too - leave it unassigned to run the notebook without the AI assistant.
+
 ## Modes
 
 - **Standalone mode** (`QUIX_PLUGIN_MODE=false`): Direct access to Marimo on port 8080. Supports optional password protection via `MARIMO_PASSWORD`.

--- a/python/others/marimo/library.json
+++ b/python/others/marimo/library.json
@@ -80,11 +80,22 @@
       "Required": false
     },
     {
-      "Name": "ANTHROPIC_API_KEY",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Token generated from https://platform.claude.com/settings/keys.",
-      "Required": false
+      "Name": "ANTHROPIC_API",
+      "InputType": "VariableGroup",
+      "Description": "Anthropic API key from a shared Variable Group.",
+      "VariableGroupId": "anthropic-api",
+      "VariableGroupName": "Anthropic API",
+      "VariableGroupDescription": "Shared Anthropic API key.",
+      "Required": false,
+      "Variables": [
+        {
+          "Key": "ANTHROPIC_API_KEY",
+          "Description": "Token generated from https://platform.claude.com/settings/keys. Used by the notebook's AI assistant.",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        }
+      ]
     }
   ]
 }

--- a/python/others/marimo/requirements.txt
+++ b/python/others/marimo/requirements.txt
@@ -1,6 +1,6 @@
 quixstreams
-quixlake-sdk>=0.2.4
-quixportal==2.0.4
+quixlake-sdk>=0.2.1
+quixportal==2.0.6
 python-dotenv
 numpy
 pandas

--- a/python/sources/MQTT/README.md
+++ b/python/sources/MQTT/README.md
@@ -19,10 +19,20 @@ The connector uses the following environment variables:
 
 - **output**: Name of the output topic to publish to.
 - **mqtt_topic**: The MQTT topic to listen to. Can use wildcards e.g. MyTopic/#
-- **mqtt_server**: The address of your MQTT server.
-- **mqtt_port**: The port of your MQTT server.
-- **mqtt_username**: Username of your MQTT user.
-- **mqtt_password**: Password for the MQTT user.
+
+The broker connection comes from the shared **`mqtt-connection`** Variable Group, so this
+source, the MQTT Sink and the bundled Mosquitto broker all agree:
+
+- **mqtt_server**: Host address of your MQTT broker, without the protocol prefix (Default: `mqtt`)
+- **mqtt_port**: Port of your MQTT broker (Default: `1883`)
+- **mqtt_username**: Username to connect to the broker with (Default: `admin`)
+- **mqtt_password**: Password to connect to the broker with
+- **mqtt_version**: MQTT protocol version. One of `3.1`, `3.1.1`, `5` (Default: `3.1.1`)
+- **mqtt_tls_enabled**: Enable TLS. One of `true`, `false` (Default: `false`, since the
+  bundled Mosquitto broker listens plaintext on 1883)
+
+`mqtt_version` and `mqtt_tls_enabled` are free text inside the group rather than
+dropdowns - the group schema has no options list. Valid values are given above.
 
 ## Requirements / Prerequisites
 

--- a/python/sources/MQTT/library.json
+++ b/python/sources/MQTT/library.json
@@ -36,53 +36,55 @@
       "Required": true
     },
     {
-      "Name": "mqtt_server",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The address of your MQTT server",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_port",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The port of your MQTT server",
-      "DefaultValue": "8883",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username of your MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_version",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "MQTT protocol version",
-      "DefaultValue": "3.1.1",
+      "Name": "MQTT_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "MQTT broker address, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "mqtt-connection",
+      "VariableGroupName": "MQTT Connection",
+      "VariableGroupDescription": "Shared MQTT broker address, port and credentials.",
       "Required": true,
-      "options": [
+      "Variables": [
         {
-          "label": "3.1",
-          "value": "3.1"
+          "Key": "mqtt_server",
+          "Description": "Host address of your MQTT broker, without the protocol prefix",
+          "DefaultValue": "mqtt",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "3.1.1",
-          "value": "3.1.1"
+          "Key": "mqtt_port",
+          "Description": "Port of your MQTT broker",
+          "DefaultValue": "1883",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "5",
-          "value": "5"
+          "Key": "mqtt_username",
+          "Description": "Username to connect to the broker with",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_password",
+          "Description": "Password to connect to the broker with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_version",
+          "Description": "MQTT protocol version. One of: 3.1, 3.1.1, 5",
+          "DefaultValue": "3.1.1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_tls_enabled",
+          "Description": "Enable TLS for the broker connection. One of: true, false. The bundled Mosquitto broker listens plaintext on 1883, so this defaults to false",
+          "DefaultValue": "false",
+          "Secret": false,
+          "Required": false
         }
       ]
     }

--- a/python/sources/MQTT/main.py
+++ b/python/sources/MQTT/main.py
@@ -31,6 +31,14 @@ def main():
     mqtt_username = os.getenv("mqtt_username")
     mqtt_password = os.getenv("mqtt_password")
 
+    # mqtt_tls_enabled comes from the shared mqtt-connection Variable Group, so this
+    # source and the MQTT Sink agree on TLS. When it is absent, fall back to the previous
+    # behaviour of enabling TLS whenever a username was supplied.
+    tls_setting = os.getenv("mqtt_tls_enabled")
+    mqtt_tls_enabled = (
+        tls_setting.lower() == "true" if tls_setting is not None else bool(mqtt_username)
+    )
+
     app = Application()
     output_topic = app.topic(output_topic_name, value_serializer="bytes")
     source = MQTTSource(
@@ -41,7 +49,7 @@ def main():
         username=mqtt_username,
         password=mqtt_password,
         version=os.getenv("mqtt_version", "3.1.1"),
-        tls_enabled=bool(mqtt_username),
+        tls_enabled=mqtt_tls_enabled,
         on_client_connect_success=on_connect_success,
         on_client_connect_failure=on_connect_failure,
     )

--- a/python/sources/MQTT/main.py
+++ b/python/sources/MQTT/main.py
@@ -32,12 +32,9 @@ def main():
     mqtt_password = os.getenv("mqtt_password")
 
     # mqtt_tls_enabled comes from the shared mqtt-connection Variable Group, so this
-    # source and the MQTT Sink agree on TLS. When it is absent, fall back to the previous
-    # behaviour of enabling TLS whenever a username was supplied.
-    tls_setting = os.getenv("mqtt_tls_enabled")
-    mqtt_tls_enabled = (
-        tls_setting.lower() == "true" if tls_setting is not None else bool(mqtt_username)
-    )
+    # source and the MQTT Sink agree on TLS. The bundled Mosquitto broker listens
+    # plaintext on 1883, hence the default.
+    mqtt_tls_enabled = os.getenv("mqtt_tls_enabled", "false").lower() == "true"
 
     app = Application()
     output_topic = app.topic(output_topic_name, value_serializer="bytes")

--- a/python/sources/confluent_kafka/README.md
+++ b/python/sources/confluent_kafka/README.md
@@ -34,10 +34,9 @@ so this source and the Confluent Kafka Sink talk to the same cluster with the sa
 - **kafka_ca_location**: Path to the SSL CA certificate file. Leave empty for the system
   defaults
 
-Note that the group default for `kafka_sasl_mechanism` is `PLAIN`, whereas this source used
-to default to `SCRAM-SHA-256`. Existing deployments carry their own value and are
-unaffected; a fresh deployment using the group will authenticate with `PLAIN` unless you
-change it.
+Note that the group default for `kafka_sasl_mechanism` is `PLAIN`, whereas this source
+used to default to `SCRAM-SHA-256`. Confluent Cloud API keys use `PLAIN`; change it in the
+group if your cluster expects SCRAM.
 
 `kafka_sasl_mechanism` is free text inside the group rather than a dropdown - the
 group schema has no options list. Valid values are given above.

--- a/python/sources/confluent_kafka/README.md
+++ b/python/sources/confluent_kafka/README.md
@@ -18,12 +18,29 @@ Then either:
 The connector uses the following environment variables:
 
 - **output**: This is the Quix Topic that will receive the stream.
-- **kafka_key**: Obtained from the Confluent Kafka portal.
-- **kafka_secret**: Obtained from the Confluent Kafka portal.
-- **kafka_broker_address**: Obtained from the Confluent Kafka portal.
 - **kafka_topic**: The Confluent Kafka Topic you wish to read from.
 - **kafka_ca_location**: (Optional) Path to the SSL CA certificate file for secure connections. If not provided, the system's default CA certificates will be used.
 - **kafka_sasl_mechanism**: (Optional) SASL mechanism for authentication. Defaults to "SCRAM-SHA-256".
+
+The cluster connection comes from the shared **`confluent-kafka-connection`** Variable Group,
+so this source and the Confluent Kafka Sink talk to the same cluster with the same API key:
+
+- **kafka_broker_address**: Bootstrap server address, obtained from the Confluent Kafka portal (Required: `True`)
+- **kafka_key**: API key, obtained from the Confluent Kafka portal (Required: `True`)
+- **kafka_secret**: API secret, obtained from the Confluent Kafka portal (Required: `True`)
+- **kafka_sasl_mechanism**: SASL mechanism. One of `PLAIN`, `SCRAM-SHA-256`,
+  `SCRAM-SHA-512`, `GSSAPI`, `OAUTHBEARER`, `AWS_MSK_IAM` (Default: `PLAIN`, which is what
+  Confluent Cloud API keys use)
+- **kafka_ca_location**: Path to the SSL CA certificate file. Leave empty for the system
+  defaults
+
+Note that the group default for `kafka_sasl_mechanism` is `PLAIN`, whereas this source used
+to default to `SCRAM-SHA-256`. Existing deployments carry their own value and are
+unaffected; a fresh deployment using the group will authenticate with `PLAIN` unless you
+change it.
+
+`kafka_sasl_mechanism` is free text inside the group rather than a dropdown - the
+group schema has no options list. Valid values are given above.
 
 ## Contribute
 

--- a/python/sources/confluent_kafka/library.json
+++ b/python/sources/confluent_kafka/library.json
@@ -28,60 +28,48 @@
       "Required": true
     },
     {
-      "Name": "kafka_key",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Obtained from the Confluent Kafka portal",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "kafka_secret",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Obtained from the Confluent Kafka portal",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "kafka_broker_address",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Obtained from the Confluent Kafka portal",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "kafka_sasl_mechanism",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "SASL mechanism for Confluent Kafka authentication",
-      "DefaultValue": "SCRAM-SHA-256",
+      "Name": "CONFLUENT_KAFKA_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Confluent Cloud broker address and API credentials from a shared Variable Group.",
+      "VariableGroupId": "confluent-kafka-connection",
+      "VariableGroupName": "Confluent Kafka Connection",
+      "VariableGroupDescription": "Shared Confluent Cloud bootstrap server and API key/secret.",
       "Required": true,
-      "options": [
+      "Variables": [
         {
-          "label": "PLAIN",
-          "value": "PLAIN"
+          "Key": "kafka_broker_address",
+          "Description": "Bootstrap server address, obtained from the Confluent Kafka portal",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "SCRAM-SHA-256",
-          "value": "SCRAM-SHA-256"
+          "Key": "kafka_key",
+          "Description": "API key, obtained from the Confluent Kafka portal",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
         },
         {
-          "label": "SCRAM-SHA-512",
-          "value": "SCRAM-SHA-512"
+          "Key": "kafka_secret",
+          "Description": "API secret, obtained from the Confluent Kafka portal",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
         },
         {
-          "label": "GSSAPI",
-          "value": "GSSAPI"
+          "Key": "kafka_sasl_mechanism",
+          "Description": "SASL mechanism for authentication. One of: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI, OAUTHBEARER, AWS_MSK_IAM. Confluent Cloud API keys use PLAIN",
+          "DefaultValue": "PLAIN",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "OAUTHBEARER",
-          "value": "OAUTHBEARER"
-        },
-        {
-          "label": "AWS_MSK_IAM",
-          "value": "AWS_MSK_IAM"
+          "Key": "kafka_ca_location",
+          "Description": "Path to the SSL CA certificate file. Leave empty to use the system's default CA certificates",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
         }
       ]
     },
@@ -92,14 +80,6 @@
       "Description": "The Confluent Kafka Topic you wish to read from",
       "DefaultValue": "",
       "Required": true
-    },
-    {
-      "Name": "kafka_ca_location",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Path to the SSL CA certificate file for secure connections. If not provided, the system's default CA certificates will be used",
-      "DefaultValue": "",
-      "Required": false
     }
   ],
   "DeploySettings": {

--- a/python/sources/environment_source/README.md
+++ b/python/sources/environment_source/README.md
@@ -23,6 +23,11 @@ The following environment variables are required for this connector:
 - **consumer_group**: *(Optional)* The Kafka consumer group used by the source environment. Defaults to `quix_environment_source`.
 - **auto_offset_reset**: *(Optional)* Specifies the offset reset policy when starting a new consumer group. Defaults to `earliest`.
 
+These come from the shared **`quix-environment-connection`** Variable Group (Quix Environment Connection), so the connection is defined once per environment rather than per deployment:
+
+- `source_workspace_id`
+- `source_sdk_token`
+
 ## How it works
 
 This project enables seamless data streaming from one Quix environment to another by utilizing the `QuixEnvironmentSource` to read data from the source environment's Kafka topic and publish it to a designated output topic.

--- a/python/sources/environment_source/library.json
+++ b/python/sources/environment_source/library.json
@@ -28,20 +28,29 @@
       "Required": false
     },
     {
-      "Name": "source_workspace_id",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Source workspace ID",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "source_sdk_token",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "SDK token for source",
-      "DefaultValue": "source_sdk_token_key",
-      "Required": true
+      "Name": "QUIX_ENVIRONMENT_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Source Quix environment id and SDK token from a shared Variable Group.",
+      "VariableGroupId": "quix-environment-connection",
+      "VariableGroupName": "Quix Environment Connection",
+      "VariableGroupDescription": "Shared source Quix environment id and SDK token.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "source_workspace_id",
+          "Description": "Id of the Quix environment to replicate from",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "source_sdk_token",
+          "Description": "SDK token for that environment",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "consumer_group",

--- a/python/sources/hivemq/README.md
+++ b/python/sources/hivemq/README.md
@@ -32,8 +32,7 @@ source and the HiveMQ Sink connect to the same broker with the same credentials:
   Cloud requires TLS on 8883)
 
 This source previously hard-coded TLS on; it now honours `mqtt_tls_enabled` so it and the
-HiveMQ Sink cannot disagree. When the variable is absent the old behaviour (TLS on) still
-applies.
+HiveMQ Sink cannot disagree.
 
 `mqtt_version` and `mqtt_tls_enabled` are free text inside the group rather than
 dropdowns - the group schema has no options list. Valid values are given above.

--- a/python/sources/hivemq/README.md
+++ b/python/sources/hivemq/README.md
@@ -19,10 +19,24 @@ The connector uses the following environment variables:
 
 - **output**: Name of the output topic to publish to.
 - **mqtt_topic**: The MQTT topic to listen to. Can use wildcards e.g. MyTopic/#
-- **mqtt_server**: The address of your MQTT server.
-- **mqtt_port**: The port of your MQTT server.
-- **mqtt_username**: Username of your MQTT user.
-- **mqtt_password**: Password for the MQTT user.
+
+The broker connection comes from the shared **`hivemq-connection`** Variable Group, so this
+source and the HiveMQ Sink connect to the same broker with the same credentials:
+
+- **mqtt_server**: Host address of your HiveMQ broker, without the protocol prefix (Required: `True`)
+- **mqtt_port**: Port of your HiveMQ broker (Default: `8883`, Required: `True`)
+- **mqtt_username**: Username of your HiveMQ user (Required: `False`)
+- **mqtt_password**: Password of your HiveMQ user (Required: `False`)
+- **mqtt_version**: MQTT protocol version. One of `3.1`, `3.1.1`, `5` (Default: `3.1.1`)
+- **mqtt_tls_enabled**: Enable TLS. One of `true`, `false` (Default: `true`, as HiveMQ
+  Cloud requires TLS on 8883)
+
+This source previously hard-coded TLS on; it now honours `mqtt_tls_enabled` so it and the
+HiveMQ Sink cannot disagree. When the variable is absent the old behaviour (TLS on) still
+applies.
+
+`mqtt_version` and `mqtt_tls_enabled` are free text inside the group rather than
+dropdowns - the group schema has no options list. Valid values are given above.
 
 ## Requirements / Prerequisites
 

--- a/python/sources/hivemq/library.json
+++ b/python/sources/hivemq/library.json
@@ -36,53 +36,55 @@
       "Required": true
     },
     {
-      "Name": "mqtt_server",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The address of your MQTT server",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_port",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The port of your MQTT server",
-      "DefaultValue": "8883",
-      "Required": true
-    },
-    {
-      "Name": "mqtt_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username of your MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the MQTT user",
-      "Required": false
-    },
-    {
-      "Name": "mqtt_version",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "MQTT protocol version",
-      "DefaultValue": "3.1.1",
+      "Name": "HIVEMQ_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "HiveMQ broker address, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "hivemq-connection",
+      "VariableGroupName": "HiveMQ Connection",
+      "VariableGroupDescription": "Shared HiveMQ broker address, port and credentials.",
       "Required": true,
-      "options": [
+      "Variables": [
         {
-          "label": "3.1",
-          "value": "3.1"
+          "Key": "mqtt_server",
+          "Description": "Host address of your HiveMQ broker, without the protocol prefix",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "3.1.1",
-          "value": "3.1.1"
+          "Key": "mqtt_port",
+          "Description": "Port of your HiveMQ broker",
+          "DefaultValue": "8883",
+          "Secret": false,
+          "Required": true
         },
         {
-          "label": "5",
-          "value": "5"
+          "Key": "mqtt_username",
+          "Description": "Username of your HiveMQ user",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_password",
+          "Description": "Password of your HiveMQ user",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "mqtt_version",
+          "Description": "MQTT protocol version. One of: 3.1, 3.1.1, 5",
+          "DefaultValue": "3.1.1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "mqtt_tls_enabled",
+          "Description": "Enable TLS for the broker connection. One of: true, false. HiveMQ Cloud requires TLS on 8883",
+          "DefaultValue": "true",
+          "Secret": false,
+          "Required": false
         }
       ]
     }

--- a/python/sources/hivemq/main.py
+++ b/python/sources/hivemq/main.py
@@ -31,6 +31,10 @@ def main():
     mqtt_username = os.getenv("mqtt_username")
     mqtt_password = os.getenv("mqtt_password")
 
+    # mqtt_tls_enabled comes from the shared hivemq-connection Variable Group, so this
+    # source and the HiveMQ Sink agree on TLS. HiveMQ Cloud requires it, hence the default.
+    mqtt_tls_enabled = os.getenv("mqtt_tls_enabled", "true").lower() == "true"
+
     app = Application()
     output_topic = app.topic(output_topic_name, value_serializer="bytes")
     source = MQTTSource(
@@ -41,7 +45,7 @@ def main():
         username=mqtt_username,
         password=mqtt_password,
         version=os.getenv("mqtt_version", "3.1.1"),
-        tls_enabled=True,
+        tls_enabled=mqtt_tls_enabled,
         on_client_connect_success=on_connect_success,
         on_client_connect_failure=on_connect_failure,
     )

--- a/python/sources/http_api_source/README.md
+++ b/python/sources/http_api_source/README.md
@@ -18,6 +18,14 @@ The code sample uses the following environment variables:
 
 - **output**: This is the output topic for hello world data.
 
+These come from the shared **`http-api-auth`** Variable Group (HTTP API Auth), so the connection is defined once per environment rather than per deployment:
+
+- `basic_auth_username`
+- `basic_auth_password`
+- `api_key`
+
+Every key is optional, so the group reference is optional too - leave it unassigned to run the endpoint without authentication.
+
 ## Contribute
 
 Submit forked projects to the Quix [GitHub](https://github.com/quixio/quix-samples) repo. Any new project that we accept will be attributed to you and you'll receive $200 in Quix credit.

--- a/python/sources/http_api_source/library.json
+++ b/python/sources/http_api_source/library.json
@@ -33,28 +33,36 @@
       "Required": true
     },
     {
-      "Name": "basic_auth_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username for basic authentication. If set along with basic_auth_password, all POST endpoints will require basic auth.",
-      "DefaultValue": "",
-      "Required": false
-    },
-    {
-      "Name": "basic_auth_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for basic authentication. If set along with basic_auth_username, all POST endpoints will require basic auth.",
-      "DefaultValue": "",
-      "Required": false
-    },
-    {
-      "Name": "api_key",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "API key for header-based authentication. If set, requests can authenticate by sending 'X-API-Key: <key>'. Can be used alongside or instead of basic auth.",
-      "DefaultValue": "",
-      "Required": false
+      "Name": "HTTP_API_AUTH",
+      "InputType": "VariableGroup",
+      "Description": "Credentials callers must present, from a shared Variable Group.",
+      "VariableGroupId": "http-api-auth",
+      "VariableGroupName": "HTTP API Auth",
+      "VariableGroupDescription": "Shared credentials callers must present to the HTTP API source.",
+      "Required": false,
+      "Variables": [
+        {
+          "Key": "basic_auth_username",
+          "Description": "Basic auth username callers must present. Leave empty to disable basic auth",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "basic_auth_password",
+          "Description": "Basic auth password callers must present",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "api_key",
+          "Description": "API key callers must present. Leave empty to disable API key auth",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        }
+      ]
     }
   ],
   "DeploySettings": {

--- a/python/sources/influxdb_2/README.md
+++ b/python/sources/influxdb_2/README.md
@@ -19,11 +19,19 @@ The connector uses the following environment variables:
 
 - **output**: This is the output topic that will receive the stream (Default: `influxdb`, Required: `True`)
 - **task_interval**: Interval to run query. Must be within the InfluxDB notation; 1s, 1m, 1h, 1d, 1w, 1mo, 1y (Default: `5m`, Required: `True`)
-- **INFLUXDB_HOST**: Host address for the InfluxDB instance. (Default: `eu-central-1-1.aws.cloud2.influxdata.com`, Required: `True`)
-- **INFLUXDB_TOKEN**: Authentication token to access InfluxDB. (Default: `<TOKEN>`, Required: `True`)
-- **INFLUXDB_ORG**: Organization name in InfluxDB. (Default: `<ORG>`, Required: `False`)
-- **INFLUXDB_BUCKET**: Bucket name in InfluxDB where data is stored. (Default: `<BUCKET>`, Required: `True`)
 - **INFLUXDB_MEASUREMENT_NAME**: The InfluxDB measurement to read data from. If not specified, the name of the output topic will be used (Default: `<INSERT MEASUREMENT>`, Required: `False`)
+
+The connection comes from the shared **`influxdb2-config`** Variable Group, so this
+source, the bundled InfluxDB v2 server and Grafana all read the same host, token and org.
+These were renamed from `INFLUXDB_HOST` / `INFLUXDB_TOKEN` / `INFLUXDB_ORG` /
+`INFLUXDB_BUCKET`, which still work for existing deployments:
+
+- **INFLUXDB2_HOST**: Base URL of the InfluxDB v2 instance, including scheme and port (Default: `http://influxdb:80`)
+- **INFLUXDB2_TOKEN**: Authentication token to access InfluxDB
+- **INFLUXDB2_ORG**: Organization name in InfluxDB (Default: `quix`)
+- **INFLUXDB2_BUCKET**: Bucket name in InfluxDB where data is stored (Default: `demo`)
+
+Point the group at InfluxDB Cloud instead by setting `INFLUXDB2_HOST` to your cloud URL.
 
 ## Requirements / Prerequisites
 

--- a/python/sources/influxdb_2/README.md
+++ b/python/sources/influxdb_2/README.md
@@ -23,8 +23,7 @@ The connector uses the following environment variables:
 
 The connection comes from the shared **`influxdb2-config`** Variable Group, so this
 source, the bundled InfluxDB v2 server and Grafana all read the same host, token and org.
-These were renamed from `INFLUXDB_HOST` / `INFLUXDB_TOKEN` / `INFLUXDB_ORG` /
-`INFLUXDB_BUCKET`, which still work for existing deployments:
+
 
 - **INFLUXDB2_HOST**: Base URL of the InfluxDB v2 instance, including scheme and port (Default: `http://influxdb:80`)
 - **INFLUXDB2_TOKEN**: Authentication token to access InfluxDB

--- a/python/sources/influxdb_2/library.json
+++ b/python/sources/influxdb_2/library.json
@@ -36,36 +36,57 @@
       "Required": true
     },
     {
-      "Name": "INFLUXDB_HOST",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host address for the InfluxDB instance.",
-      "DefaultValue": "eu-central-1-1.aws.cloud2.influxdata.com",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_TOKEN",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Authentication token to access InfluxDB.",
-      "DefaultValue": "<TOKEN>",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_ORG",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Organization name in InfluxDB.",
-      "DefaultValue": "<ORG>",
-      "Required": true
-    },
-    {
-      "Name": "INFLUXDB_BUCKET",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Bucket name in InfluxDB where data is stored.",
-      "DefaultValue": "<BUCKET>",
-      "Required": true
+      "Name": "INFLUXDB2_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "InfluxDB v2 connection details and admin token from a shared Variable Group.",
+      "VariableGroupId": "influxdb2-config",
+      "VariableGroupName": "InfluxDB v2 config",
+      "VariableGroupDescription": "Shared InfluxDB v2 connection details, admin token and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "INFLUXDB2_HOST",
+          "Description": "Base URL clients use to reach InfluxDB v2, including the http:// scheme and port",
+          "DefaultValue": "http://influxdb:80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_TOKEN",
+          "Description": "Admin token. Seeds server auth on first boot and authenticates clients",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_ORG",
+          "Description": "Organization the server is initialised with, and that clients query",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_BUCKET",
+          "Description": "Bucket the server is initialised with, and that clients read and write",
+          "DefaultValue": "demo",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_USERNAME",
+          "Description": "Admin username the server is initialised with",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "INFLUXDB2_PASSWORD",
+          "Description": "Admin password the server is initialised with",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "INFLUXDB_MEASUREMENT_NAME",

--- a/python/sources/influxdb_2/main.py
+++ b/python/sources/influxdb_2/main.py
@@ -28,14 +28,32 @@ serializer = JSONSerializer()
 topic_name = os.environ["output"]
 topic = app.topic(topic_name)
 
-influxdb2_client = influxdb_client.InfluxDBClient(token=os.environ["INFLUXDB_TOKEN"],
-                        org=os.environ["INFLUXDB_ORG"],
-                        url=os.environ['INFLUXDB_HOST'])
+
+def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
+    """
+    Read a connection env var by the name the shared influxdb2-config Variable Group injects,
+    falling back to the legacy INFLUXDB_* name so deployments created before the rename
+    keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name) or default
+    if value is None:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
+# The connection comes from the shared influxdb2-config Variable Group, so this source,
+# the bundled InfluxDB v2 server and Grafana all read the same host, token and org.
+influxdb_host = conn_var("INFLUXDB2_HOST", "INFLUXDB_HOST")
+influxdb_org = conn_var("INFLUXDB2_ORG", "INFLUXDB_ORG")
+
+influxdb2_client = influxdb_client.InfluxDBClient(token=conn_var("INFLUXDB2_TOKEN", "INFLUXDB_TOKEN"),
+                        org=influxdb_org,
+                        url=influxdb_host)
 
 query_api = influxdb2_client.query_api()
 
 interval = os.environ.get("task_interval", "5m")
-bucket = os.environ.get("INFLUXDB_BUCKET", "placeholder-bucket")
+bucket = conn_var("INFLUXDB2_BUCKET", "INFLUXDB_BUCKET", "placeholder-bucket")
 
 # Global variable to control the main loop's execution
 run = True
@@ -84,7 +102,7 @@ def get_data():
             '''
             logger.info(f"Sending query: {flux_query}")
 
-            table = query_api.query_data_frame(query=flux_query,org=os.environ['INFLUXDB_ORG'])
+            table = query_api.query_data_frame(query=flux_query,org=influxdb_org)
 
             # Renaming time column to distinguish it from other timestamp types
             # table.rename(columns={'_time': 'original_time'}, inplace=True)
@@ -125,7 +143,7 @@ def main():
         else:
             print(f"ERROR! InfluxDB health check failed: status={health.status}, message={health.message}")
     except Exception as e:
-        print(f"ERROR! Failed to connect to InfluxDB at {os.environ['INFLUXDB_HOST']}: {e}")
+        print(f"ERROR! Failed to connect to InfluxDB at {influxdb_host}: {e}")
 
     # Create a pre-configured Producer object.
     # Producer is already setup to use Quix brokers.

--- a/python/sources/influxdb_2/main.py
+++ b/python/sources/influxdb_2/main.py
@@ -28,32 +28,19 @@ serializer = JSONSerializer()
 topic_name = os.environ["output"]
 topic = app.topic(topic_name)
 
-
-def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
-    """
-    Read a connection env var by the name the shared influxdb2-config Variable Group injects,
-    falling back to the legacy INFLUXDB_* name so deployments created before the rename
-    keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name) or default
-    if value is None:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 # The connection comes from the shared influxdb2-config Variable Group, so this source,
 # the bundled InfluxDB v2 server and Grafana all read the same host, token and org.
-influxdb_host = conn_var("INFLUXDB2_HOST", "INFLUXDB_HOST")
-influxdb_org = conn_var("INFLUXDB2_ORG", "INFLUXDB_ORG")
+influxdb_host = os.environ["INFLUXDB2_HOST"]
+influxdb_org = os.environ["INFLUXDB2_ORG"]
 
-influxdb2_client = influxdb_client.InfluxDBClient(token=conn_var("INFLUXDB2_TOKEN", "INFLUXDB_TOKEN"),
+influxdb2_client = influxdb_client.InfluxDBClient(token=os.environ["INFLUXDB2_TOKEN"],
                         org=influxdb_org,
                         url=influxdb_host)
 
 query_api = influxdb2_client.query_api()
 
 interval = os.environ.get("task_interval", "5m")
-bucket = conn_var("INFLUXDB2_BUCKET", "INFLUXDB_BUCKET", "placeholder-bucket")
+bucket = os.getenv("INFLUXDB2_BUCKET", "placeholder-bucket")
 
 # Global variable to control the main loop's execution
 run = True

--- a/python/sources/influxdb_3/library.json
+++ b/python/sources/influxdb_3/library.json
@@ -41,7 +41,7 @@
       "Description": "Shared InfluxDB v3 connection details and admin token (used by this server and by every client that reads/writes it)",
       "VariableGroupId": "influxdb3-config",
       "VariableGroupName": "InfluxDB v3 config",
-      "VariableGroupDescription": "Shared InfluxDB v3 connection details and admin token (used by this server and by every client that reads/writes it)",
+      "VariableGroupDescription": "Shared InfluxDB v3 connection details and admin token, used by the server and all its clients",
       "Required": true,
       "Variables": [
         {

--- a/python/sources/kafka/README.md
+++ b/python/sources/kafka/README.md
@@ -12,6 +12,16 @@ This source template replicates data from a Kafka topic to a Quix topic using th
 
 ## Environment Variables
 
+These come from the shared **`source-kafka-connection`** Variable Group (Source Kafka Connection), so the connection is defined once per environment rather than per deployment:
+
+- `SOURCE_BROKER_ADDRESS`
+- `SOURCE_KAFKA_SASL_USERNAME`
+- `SOURCE_KAFKA_SASL_PASSWORD`
+- `SOURCE_KAFKA_SASL_MECHANISM`
+- `SOURCE_KAFKA_SSL_CA_LOCATION`
+
+`SOURCE_KAFKA_SASL_MECHANISM` is free text inside the group rather than a dropdown; its valid values are listed above.
+
 ### Required
 
 - **output**: The Quix topic that will receive the replicated data

--- a/python/sources/kafka/library.json
+++ b/python/sources/kafka/library.json
@@ -28,12 +28,50 @@
       "Required": true
     },
     {
-      "Name": "SOURCE_BROKER_ADDRESS",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The source Kafka broker address (e.g., localhost:9092 or broker.example.com:9092)",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "SOURCE_KAFKA_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "External Kafka broker address and SASL credentials from a shared Variable Group.",
+      "VariableGroupId": "source-kafka-connection",
+      "VariableGroupName": "Source Kafka Connection",
+      "VariableGroupDescription": "Shared external Kafka broker address and SASL credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "SOURCE_BROKER_ADDRESS",
+          "Description": "Address of the external Kafka broker to replicate from",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "SOURCE_KAFKA_SASL_USERNAME",
+          "Description": "SASL username, if the broker requires authentication",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "SOURCE_KAFKA_SASL_PASSWORD",
+          "Description": "SASL password, if the broker requires authentication",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "SOURCE_KAFKA_SASL_MECHANISM",
+          "Description": "SASL mechanism. One of: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI, OAUTHBEARER",
+          "DefaultValue": "SCRAM-SHA-256",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "SOURCE_KAFKA_SSL_CA_LOCATION",
+          "Description": "Path to the SSL CA certificate file. Leave empty for the system defaults",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "SOURCE_TOPIC",
@@ -135,64 +173,6 @@
       "InputType": "FreeText",
       "Description": "Timeout for shutting down the source in seconds",
       "DefaultValue": "10",
-      "Required": false
-    },
-    {
-      "Name": "SOURCE_KAFKA_SASL_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "SASL username for source Kafka authentication (optional)",
-      "DefaultValue": "",
-      "Required": false
-    },
-    {
-      "Name": "SOURCE_KAFKA_SASL_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "SASL password for source Kafka authentication (optional)",
-      "DefaultValue": "",
-      "Required": false
-    },
-    {
-      "Name": "SOURCE_KAFKA_SASL_MECHANISM",
-      "Type": "EnvironmentVariable",
-      "InputType": "Options",
-      "Description": "SASL mechanism for authentication",
-      "DefaultValue": "SCRAM-SHA-256",
-      "Required": false,
-      "options": [
-        {
-          "label": "PLAIN",
-          "value": "PLAIN"
-        },
-        {
-          "label": "SCRAM-SHA-256",
-          "value": "SCRAM-SHA-256"
-        },
-        {
-          "label": "SCRAM-SHA-512",
-          "value": "SCRAM-SHA-512"
-        },
-        {
-          "label": "GSSAPI",
-          "value": "GSSAPI"
-        },
-        {
-          "label": "OAUTHBEARER",
-          "value": "OAUTHBEARER"
-        },
-        {
-          "label": "AWS_MSK_IAM",
-          "value": "AWS_MSK_IAM"
-        }
-      ]
-    },
-    {
-      "Name": "SOURCE_KAFKA_SSL_CA_LOCATION",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Path to the SSL CA certificate file for secure connections. If not provided, system default CA certificates will be used",
-      "DefaultValue": "",
       "Required": false
     },
     {

--- a/python/sources/opc_ua_client/README.md
+++ b/python/sources/opc_ua_client/README.md
@@ -15,9 +15,15 @@ Clicking `Customise` allows you to view or save the code to the repo that backs 
 The connector uses the following environment variables:
 
 - **output**: Name of the output topic to publish to.
-- **OPC_SERVER_URL**: The URL to your OPC UA server.
-- **OPC_NAMESPACE**: The namespace of the data coming from your OPC UA server.
 - **PARAMETER_NAMES_TO_PROCESS**: List of parameters from your OPC UA server that you want to process. e.g. ['a', 'b', 'c']. NB:Use single quotes.
+
+The server details come from the shared **`opcua-connection`** Variable Group, so this
+source and the bundled OPC UA Server sample stay in agreement:
+
+- **OPC_SERVER_URL**: URL of your OPC UA server (Default: `https://intopcserver:4840/freeopcua/server/`,
+  which is the OPC UA Server sample's internal service name)
+- **OPC_NAMESPACE**: The namespace of the data coming from your OPC UA server
+  (Default: `http://quix.freeopcua.io`)
 
 
 ## Contribute

--- a/python/sources/opc_ua_client/library.json
+++ b/python/sources/opc_ua_client/library.json
@@ -28,20 +28,29 @@
       "Required": true
     },
     {
-      "Name": "OPC_SERVER_URL",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The URL to your OPC UA server",
-      "DefaultValue": "https://intopcserver:4840/freeopcua/server/",
-      "Required": true
-    },
-    {
-      "Name": "OPC_NAMESPACE",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The namespace of the data coming from your OPC UA server",
-      "DefaultValue": "http://quix.freeopcua.io",
-      "Required": true
+      "Name": "OPCUA_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "OPC UA server URL and namespace from a shared Variable Group.",
+      "VariableGroupId": "opcua-connection",
+      "VariableGroupName": "OPC UA Connection",
+      "VariableGroupDescription": "Shared OPC UA server URL and namespace.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "OPC_SERVER_URL",
+          "Description": "URL of your OPC UA server. Defaults to the bundled OPC UA Server sample on the internal Quix network",
+          "DefaultValue": "https://intopcserver:4840/freeopcua/server/",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "OPC_NAMESPACE",
+          "Description": "Namespace of the data coming from your OPC UA server",
+          "DefaultValue": "http://quix.freeopcua.io",
+          "Secret": false,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "PARAMETER_NAMES_TO_PROCESS",

--- a/python/sources/postgres_cdc/README.md
+++ b/python/sources/postgres_cdc/README.md
@@ -18,13 +18,11 @@ Then either:
 The connector uses the following environment variables:
 
 - **output**: Name of the output topic to write into.
-- **PG_SCHEMA**: The name of the schema for CDC.
-- **PG_TABLE**: The name of the table for CDC.
+- **POSTGRES_SCHEMA**: The name of the schema for CDC.
+- **POSTGRES_TABLE**: The name of the table for CDC.
 
 The connection comes from the shared **`postgres-connection`** Variable Group, so this
-source, the PostgreSQL Sink and the bundled PostgreSQL server all agree. These were
-renamed from `PG_HOST` / `PG_PORT` / `PG_USER` / `PG_PASSWORD` / `PG_DATABASE`, which
-still work for existing deployments:
+source, the PostgreSQL Sink and the bundled PostgreSQL server all agree:
 
 - **POSTGRES_HOST**: Host address of the PostgreSQL instance (Default: `postgresql`)
 - **POSTGRES_PORT**: Port of the PostgreSQL instance (Default: `80`)

--- a/python/sources/postgres_cdc/README.md
+++ b/python/sources/postgres_cdc/README.md
@@ -18,13 +18,19 @@ Then either:
 The connector uses the following environment variables:
 
 - **output**: Name of the output topic to write into.
-- **PG_HOST**: The IP address or fully qualified domain name of your server.
-- **PG_PORT**: The Port number to use for communication with the server.
-- **PG_DATABASE**: The name of the database for CDC.
-- **PG_USER**: The username of the sink should use to interact with the database.
-- **PG_PASSWORD**: The password for the user configured above.
 - **PG_SCHEMA**: The name of the schema for CDC.
 - **PG_TABLE**: The name of the table for CDC.
+
+The connection comes from the shared **`postgres-connection`** Variable Group, so this
+source, the PostgreSQL Sink and the bundled PostgreSQL server all agree. These were
+renamed from `PG_HOST` / `PG_PORT` / `PG_USER` / `PG_PASSWORD` / `PG_DATABASE`, which
+still work for existing deployments:
+
+- **POSTGRES_HOST**: Host address of the PostgreSQL instance (Default: `postgresql`)
+- **POSTGRES_PORT**: Port of the PostgreSQL instance (Default: `80`)
+- **POSTGRES_DB**: The name of the database for CDC (Default: `quix`)
+- **POSTGRES_USER**: The username the source uses to interact with the database (Default: `admin`)
+- **POSTGRES_PASSWORD**: The password for the user configured above
 
 ## Requirements / Prerequisites
 

--- a/python/sources/postgres_cdc/library.json
+++ b/python/sources/postgres_cdc/library.json
@@ -74,7 +74,7 @@
       ]
     },
     {
-      "Name": "PG_SCHEMA",
+      "Name": "POSTGRES_SCHEMA",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
       "Description": "Name of schema for CDC",
@@ -82,7 +82,7 @@
       "Required": true
     },
     {
-      "Name": "PG_TABLE",
+      "Name": "POSTGRES_TABLE",
       "Type": "EnvironmentVariable",
       "InputType": "FreeText",
       "Description": "Name of table for CDC",

--- a/python/sources/postgres_cdc/library.json
+++ b/python/sources/postgres_cdc/library.json
@@ -28,44 +28,50 @@
       "Required": true
     },
     {
-      "Name": "PG_HOST",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host name of Postgres",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "PG_PORT",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Port of Postgres",
-      "DefaultValue": "5432",
-      "Required": true
-    },
-    {
-      "Name": "PG_USER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username of Postgres",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "PG_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password of Postgres",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "PG_DATABASE",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Database name of Postgres",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "POSTGRES_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "PostgreSQL host, port, database and credentials from a shared Variable Group.",
+      "VariableGroupId": "postgres-connection",
+      "VariableGroupName": "PostgreSQL Connection",
+      "VariableGroupDescription": "Shared PostgreSQL host, port, database and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "POSTGRES_HOST",
+          "Description": "Host address of the PostgreSQL instance",
+          "DefaultValue": "postgresql",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_PORT",
+          "Description": "Port of the PostgreSQL instance (80 for the bundled server on the internal Quix network)",
+          "DefaultValue": "80",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_DB",
+          "Description": "Database name to connect to, and to initialise the server with",
+          "DefaultValue": "quix",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_USER",
+          "Description": "Username for the PostgreSQL database",
+          "DefaultValue": "admin",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "POSTGRES_PASSWORD",
+          "Description": "Password for the PostgreSQL database",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     },
     {
       "Name": "PG_SCHEMA",

--- a/python/sources/postgres_cdc/main.py
+++ b/python/sources/postgres_cdc/main.py
@@ -11,8 +11,8 @@ load_dotenv()
 
 # Global Variables
 PG_SLOT_NAME = "replication_slot"
-PG_SCHEMA = os.environ["PG_SCHEMA"]
-PG_TABLE = os.environ["PG_TABLE"]
+PG_SCHEMA = os.environ["POSTGRES_SCHEMA"]
+PG_TABLE = os.environ["POSTGRES_TABLE"]
 PG_PUBLICATION_NAME = f"pub_{PG_SCHEMA}_{PG_TABLE}"
 PG_TABLE_NAME = f"{PG_SCHEMA}.{PG_TABLE}"
 WAIT_INTERVAL = 0.1

--- a/python/sources/postgres_cdc/postgres_helper.py
+++ b/python/sources/postgres_cdc/postgres_helper.py
@@ -1,13 +1,26 @@
 import psycopg2
 import os
 
+def conn_var(new_name: str, legacy_name: str) -> str:
+    """
+    Read a connection env var by the name the shared postgres-connection Variable Group
+    injects, falling back to the legacy PG_* name so deployments created before the
+    rename keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name)
+    if not value:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
 def connect_postgres():
-    # Postgres Constants
-    PG_HOST = os.environ["PG_HOST"]
-    PG_PORT = os.environ["PG_PORT"]
-    PG_USER = os.environ["PG_USER"]
-    PG_PASSWORD = os.environ["PG_PASSWORD"]
-    PG_DATABASE = os.environ["PG_DATABASE"]
+    # Postgres Constants - the connection comes from the shared postgres-connection
+    # Variable Group, so the CDC source, the sink and the bundled server all agree.
+    PG_HOST = conn_var("POSTGRES_HOST", "PG_HOST")
+    PG_PORT = conn_var("POSTGRES_PORT", "PG_PORT")
+    PG_USER = conn_var("POSTGRES_USER", "PG_USER")
+    PG_PASSWORD = conn_var("POSTGRES_PASSWORD", "PG_PASSWORD")
+    PG_DATABASE = conn_var("POSTGRES_DB", "PG_DATABASE")
 
     conn = psycopg2.connect(
         database = PG_DATABASE, user = PG_USER, password = PG_PASSWORD, host = PG_HOST, port = PG_PORT

--- a/python/sources/postgres_cdc/postgres_helper.py
+++ b/python/sources/postgres_cdc/postgres_helper.py
@@ -1,26 +1,14 @@
 import psycopg2
 import os
 
-def conn_var(new_name: str, legacy_name: str) -> str:
-    """
-    Read a connection env var by the name the shared postgres-connection Variable Group
-    injects, falling back to the legacy PG_* name so deployments created before the
-    rename keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name)
-    if not value:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 def connect_postgres():
     # Postgres Constants - the connection comes from the shared postgres-connection
     # Variable Group, so the CDC source, the sink and the bundled server all agree.
-    PG_HOST = conn_var("POSTGRES_HOST", "PG_HOST")
-    PG_PORT = conn_var("POSTGRES_PORT", "PG_PORT")
-    PG_USER = conn_var("POSTGRES_USER", "PG_USER")
-    PG_PASSWORD = conn_var("POSTGRES_PASSWORD", "PG_PASSWORD")
-    PG_DATABASE = conn_var("POSTGRES_DB", "PG_DATABASE")
+    PG_HOST = os.environ["POSTGRES_HOST"]
+    PG_PORT = os.environ["POSTGRES_PORT"]
+    PG_USER = os.environ["POSTGRES_USER"]
+    PG_PASSWORD = os.environ["POSTGRES_PASSWORD"]
+    PG_DATABASE = os.environ["POSTGRES_DB"]
 
     conn = psycopg2.connect(
         database = PG_DATABASE, user = PG_USER, password = PG_PASSWORD, host = PG_HOST, port = PG_PORT

--- a/python/sources/redis_source/README.md
+++ b/python/sources/redis_source/README.md
@@ -20,10 +20,14 @@ Then either:
 The connector uses the following environment variables:
 
 - **output**: This is the output topic that will receive the stream (Default: `output`, Required: `True`)
-- **redis_host**: Host address for the Redis instance (Required: `True`)
-- **redis_port**: Port for the Redis instance (Default: `6379`, Required: `True`)
-- **redis_password**: Password for the Redis instance (Default: `None`, Required: `False`)
-- **redis_username**: Username for the Redis instance (Default: `None`, Required: `False`)
+
+The Redis connection comes from the shared **`redis-connection`** Variable Group, so this
+source, the Redis Sink and anything else pointing at the same instance stay in sync:
+
+- **redis_host**: Host address of your Redis instance (Required: `True`)
+- **redis_port**: Port of your Redis instance (Default: `6379`, Required: `True`)
+- **redis_username**: Username for your Redis instance, if it requires one (Required: `False`)
+- **redis_password**: Password for your Redis instance, if it requires one (Required: `False`)
 
 ## Requirements / Prerequisites
 

--- a/python/sources/redis_source/library.json
+++ b/python/sources/redis_source/library.json
@@ -28,36 +28,43 @@
       "Required": true
     },
     {
-      "Name": "redis_host",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Host address for the Redis instance",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "redis_port",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Port for the Redis instance",
-      "DefaultValue": "6379",
-      "Required": true
-    },
-    {
-      "Name": "redis_password",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Password for the Redis instance",
-      "DefaultValue": "",
-      "Required": false
-    },
-    {
-      "Name": "redis_username",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Username for the Redis instance",
-      "DefaultValue": "",
-      "Required": false
+      "Name": "REDIS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "Redis host, port and credentials from a shared Variable Group.",
+      "VariableGroupId": "redis-connection",
+      "VariableGroupName": "Redis Connection",
+      "VariableGroupDescription": "Shared Redis host, port and credentials.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "redis_host",
+          "Description": "Host address of your Redis instance",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "redis_port",
+          "Description": "Port of your Redis instance",
+          "DefaultValue": "6379",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "redis_username",
+          "Description": "Username for your Redis instance, if it requires one",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        },
+        {
+          "Key": "redis_password",
+          "Description": "Password for your Redis instance, if it requires one",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        }
+      ]
     }
   ],
   "DeploySettings": {

--- a/python/sources/s3_source/README.md
+++ b/python/sources/s3_source/README.md
@@ -28,13 +28,20 @@ This service continuously monitors a specified S3 bucket and folder path for new
 
 - **output**: Name of the output Kafka topic (default: `s3-data`)
 - **S3_BUCKET**: S3 bucket URI (e.g., `s3://quix-test-bucket/configurations/`)
-- **S3_REGION**: AWS region of the S3 bucket (e.g., `eu-west-2`)
-- **S3_SECRET**: AWS Secret Access Key (stored as secret)
-- **S3_ACCESS_KEY_ID**: AWS Access Key ID (stored as secret)
 - **S3_FOLDER_PATH**: Folder path within bucket to monitor (e.g., `configurations`)
 - **S3_FILE_FORMAT**: Expected file format (e.g., `xml`)
 - **S3_FILE_COMPRESSION**: Compression type (e.g., `gzip`)
 - **POLL_INTERVAL_SECONDS**: Polling interval in seconds (default: 30)
+
+Credentials, region and endpoint come from the shared **`aws-connection`** Variable Group,
+so every AWS connector in the pipeline uses one set of credentials. These were renamed
+from `S3_ACCESS_KEY_ID` / `S3_SECRET` / `S3_REGION`, which still work for existing
+deployments:
+
+- **AWS_ACCESS_KEY_ID**: AWS access key ID (optional - omit both keys to use an IAM role or anonymous access)
+- **AWS_SECRET_ACCESS_KEY**: AWS secret access key (optional, as above)
+- **AWS_REGION**: AWS region of the S3 bucket (default: `us-east-1`)
+- **AWS_ENDPOINT_URL**: Custom endpoint for S3-compatible storage such as MinIO. Leave empty for AWS
 
 ## Configuration Example
 
@@ -42,7 +49,7 @@ Based on the current deployment configuration:
 
 ```yaml
 S3_BUCKET: "s3://quix-test-bucket/configurations/"
-S3_REGION: "eu-west-2"
+AWS_REGION: "eu-west-2"
 S3_FOLDER_PATH: "configurations"
 S3_FILE_FORMAT: "xml"
 S3_FILE_COMPRESSION: "gzip"
@@ -67,9 +74,9 @@ pip install -r requirements.txt
 
 # Set environment variables
 export S3_BUCKET="s3://your-bucket/path/"
-export S3_REGION="your-region"
-export S3_ACCESS_KEY_ID="your-access-key"
-export S3_SECRET="your-secret-key"
+export AWS_REGION="your-region"
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
 export S3_FOLDER_PATH="configurations"
 export output="s3-data"
 

--- a/python/sources/s3_source/README.md
+++ b/python/sources/s3_source/README.md
@@ -34,9 +34,7 @@ This service continuously monitors a specified S3 bucket and folder path for new
 - **POLL_INTERVAL_SECONDS**: Polling interval in seconds (default: 30)
 
 Credentials, region and endpoint come from the shared **`aws-connection`** Variable Group,
-so every AWS connector in the pipeline uses one set of credentials. These were renamed
-from `S3_ACCESS_KEY_ID` / `S3_SECRET` / `S3_REGION`, which still work for existing
-deployments:
+so every AWS connector in the pipeline uses one set of credentials:
 
 - **AWS_ACCESS_KEY_ID**: AWS access key ID (optional - omit both keys to use an IAM role or anonymous access)
 - **AWS_SECRET_ACCESS_KEY**: AWS secret access key (optional, as above)

--- a/python/sources/s3_source/library.json
+++ b/python/sources/s3_source/library.json
@@ -35,28 +35,50 @@
       "Required": true
     },
     {
-      "Name": "S3_REGION",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "The region of your S3 bucket",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "S3_SECRET",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Your AWS secret",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "S3_ACCESS_KEY_ID",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "Your AWS Access Key",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "AWS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "AWS credentials and region from a shared Variable Group.",
+      "VariableGroupId": "aws-connection",
+      "VariableGroupName": "AWS Connection",
+      "VariableGroupDescription": "Shared AWS credentials, region and optional S3-compatible endpoint.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "AWS_ACCESS_KEY_ID",
+          "Description": "Your AWS access key ID",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SECRET_ACCESS_KEY",
+          "Description": "Your AWS secret access key",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_REGION",
+          "Description": "The AWS region your resources live in",
+          "DefaultValue": "us-east-1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SESSION_TOKEN",
+          "Description": "AWS session token, for temporary credentials only",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "AWS_ENDPOINT_URL",
+          "Description": "Custom endpoint for S3-compatible storage such as MinIO. Leave empty for AWS",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "S3_FOLDER_PREFIX",

--- a/python/sources/s3_source/main.py
+++ b/python/sources/s3_source/main.py
@@ -8,12 +8,30 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Configuration
-AWS_ACCESS_KEY_ID = os.getenv("S3_ACCESS_KEY_ID")
-AWS_SECRET_ACCESS_KEY = os.getenv("S3_SECRET")
+def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
+    """
+    Read a connection env var by the name the shared aws-connection Variable Group
+    injects, falling back to the legacy name so deployments created before the rename
+    keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name) or default
+    if value is None:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
+# Credentials, region and endpoint come from the shared aws-connection Variable Group,
+# falling back to the legacy S3_* names so existing deployments keep working. These two
+# stay optional (`or None`): S3FileWatcher falls back to the ambient credential chain -
+# an IAM role, or anonymous access - when neither is supplied.
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID") or os.getenv("S3_ACCESS_KEY_ID") or None
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY") or os.getenv("S3_SECRET") or None
 S3_BUCKET_NAME = os.environ["S3_BUCKET"]
 S3_FOLDER_PREFIX = os.getenv("S3_FOLDER_PREFIX", "")
-AWS_REGION = os.getenv("S3_REGION", "us-east-1")
-AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL")  # For MinIO or custom S3-compatible endpoints
+AWS_REGION = conn_var("AWS_REGION", "S3_REGION", "us-east-1")
+# For MinIO or custom S3-compatible endpoints. `or None` so a blank value from the
+# Variable Group is not passed to boto3 as an empty endpoint URL.
+AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL") or None
 TOPIC_NAME = os.environ["output"]
 POLL_INTERVAL = int(os.getenv("POLL_INTERVAL_SECONDS", "30"))
 

--- a/python/sources/s3_source/main.py
+++ b/python/sources/s3_source/main.py
@@ -8,27 +8,14 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Configuration
-def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
-    """
-    Read a connection env var by the name the shared aws-connection Variable Group
-    injects, falling back to the legacy name so deployments created before the rename
-    keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name) or default
-    if value is None:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
-# Credentials, region and endpoint come from the shared aws-connection Variable Group,
-# falling back to the legacy S3_* names so existing deployments keep working. These two
-# stay optional (`or None`): S3FileWatcher falls back to the ambient credential chain -
-# an IAM role, or anonymous access - when neither is supplied.
-AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID") or os.getenv("S3_ACCESS_KEY_ID") or None
-AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY") or os.getenv("S3_SECRET") or None
+# Credentials, region and endpoint come from the shared aws-connection Variable Group.
+# These two stay optional (`or None`): S3FileWatcher falls back to the ambient credential
+# chain - an IAM role, or anonymous access - when neither is supplied.
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID") or None
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY") or None
 S3_BUCKET_NAME = os.environ["S3_BUCKET"]
 S3_FOLDER_PREFIX = os.getenv("S3_FOLDER_PREFIX", "")
-AWS_REGION = conn_var("AWS_REGION", "S3_REGION", "us-east-1")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 # For MinIO or custom S3-compatible endpoints. `or None` so a blank value from the
 # Variable Group is not passed to boto3 as an empty endpoint URL.
 AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL") or None

--- a/python/sources/segment_webhook/README.md
+++ b/python/sources/segment_webhook/README.md
@@ -24,6 +24,10 @@ This connector uses the following environment variables:
 - **output**: The output topic to stream Segment data into
 - **shared_secret**: The secret you configured in Segment
 
+These come from the shared **`segment-webhook-auth`** Variable Group (Segment Webhook Auth), so the connection is defined once per environment rather than per deployment:
+
+- `shared_secret`
+
 ## Contribute
 
 Submit forked projects to the Quix [GitHub](https://github.com/quixio/quix-samples) repo. Any new project that we accept will be attributed to you and you'll receive $200 in Quix credit.

--- a/python/sources/segment_webhook/library.json
+++ b/python/sources/segment_webhook/library.json
@@ -28,12 +28,22 @@
       "Required": true
     },
     {
-      "Name": "shared_secret",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "The secret you configured in Segment",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "SEGMENT_WEBHOOK_AUTH",
+      "InputType": "VariableGroup",
+      "Description": "Segment shared secret from a shared Variable Group.",
+      "VariableGroupId": "segment-webhook-auth",
+      "VariableGroupName": "Segment Webhook Auth",
+      "VariableGroupDescription": "Shared Segment shared secret used to verify webhook signatures.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "shared_secret",
+          "Description": "The shared secret configured on your Segment webhook, used to verify signatures",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        }
+      ]
     }
   ],
   "DeploySettings": {

--- a/python/sources/snowplow_source/README.md
+++ b/python/sources/snowplow_source/README.md
@@ -23,9 +23,7 @@ The connector uses the following environment variables:
 - **aws_stream_name**: The name of the AWS stream you want to use.
 
 Credentials and region come from the shared **`aws-connection`** Variable Group, so every
-AWS connector in the pipeline uses one set of credentials. These were renamed from
-`aws_access_key_id` / `aws_secret_access_key` / `aws_region_name`, which still work for
-existing deployments:
+AWS connector in the pipeline uses one set of credentials:
 
 - **AWS_ACCESS_KEY_ID**: AWS access key ID.
 - **AWS_SECRET_ACCESS_KEY**: AWS secret access key.

--- a/python/sources/snowplow_source/README.md
+++ b/python/sources/snowplow_source/README.md
@@ -20,10 +20,16 @@ Then either:
 The connector uses the following environment variables:
 
 - **output**: This is the Quix Topic that will receive the stream.
-- **aws_access_key_id**: AWS Access Key Id.
-- **aws_secret_access_key**: AWS Secret Access Key.
-- **aws_region_name**: AWS Region Name.
 - **aws_stream_name**: The name of the AWS stream you want to use.
+
+Credentials and region come from the shared **`aws-connection`** Variable Group, so every
+AWS connector in the pipeline uses one set of credentials. These were renamed from
+`aws_access_key_id` / `aws_secret_access_key` / `aws_region_name`, which still work for
+existing deployments:
+
+- **AWS_ACCESS_KEY_ID**: AWS access key ID.
+- **AWS_SECRET_ACCESS_KEY**: AWS secret access key.
+- **AWS_REGION**: AWS region name (Default: `us-east-1`).
 
 ## Requirements/prerequisites
 

--- a/python/sources/snowplow_source/library.json
+++ b/python/sources/snowplow_source/library.json
@@ -29,28 +29,50 @@
       "Required": true
     },
     {
-      "Name": "aws_access_key_id",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "AWS Access Key Id",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "aws_secret_access_key",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "AWS Secret Access Key",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "aws_region_name",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "AWS Region Name",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "AWS_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "AWS credentials and region from a shared Variable Group.",
+      "VariableGroupId": "aws-connection",
+      "VariableGroupName": "AWS Connection",
+      "VariableGroupDescription": "Shared AWS credentials, region and optional S3-compatible endpoint.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "AWS_ACCESS_KEY_ID",
+          "Description": "Your AWS access key ID",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SECRET_ACCESS_KEY",
+          "Description": "Your AWS secret access key",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "AWS_REGION",
+          "Description": "The AWS region your resources live in",
+          "DefaultValue": "us-east-1",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "AWS_SESSION_TOKEN",
+          "Description": "AWS session token, for temporary credentials only",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": false
+        },
+        {
+          "Key": "AWS_ENDPOINT_URL",
+          "Description": "Custom endpoint for S3-compatible storage such as MinIO. Leave empty for AWS",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "aws_stream_name",

--- a/python/sources/snowplow_source/main.py
+++ b/python/sources/snowplow_source/main.py
@@ -21,6 +21,18 @@ producer_topic = None
 quix_producer = None
 
 
+def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
+    """
+    Read a connection env var by the name the shared aws-connection Variable Group
+    injects, falling back to the legacy name so deployments created before the rename
+    keep working.
+    """
+    value = os.getenv(new_name) or os.getenv(legacy_name) or default
+    if value is None:
+        raise KeyError(f"{new_name} (or legacy {legacy_name})")
+    return value
+
+
 def connect_to_aws() -> bool:
     global kinesis_client
 
@@ -31,9 +43,9 @@ def connect_to_aws() -> bool:
     try:
         kinesis_client = boto3.client(
             'kinesis',
-            aws_access_key_id = os.environ["aws_access_key_id"],
-            aws_secret_access_key = os.environ["aws_secret_access_key"],
-            region_name = os.environ["aws_region_name"]
+            aws_access_key_id = conn_var("AWS_ACCESS_KEY_ID", "aws_access_key_id"),
+            aws_secret_access_key = conn_var("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
+            region_name = conn_var("AWS_REGION", "aws_region_name")
         )
     except Exception as e:
         print(f"ERROR! - Failed to connect to AWS: {e}")
@@ -117,10 +129,16 @@ def connect_to_quix():
 def main():
     global run
 
-    # validate the required env vars have been set supplied
-    required_env_vars = ["aws_access_key_id", "aws_secret_access_key", "aws_region_name", "output"]
-    for var in required_env_vars:
-        if var not in os.environ:
+    # validate the required env vars have been set supplied. The AWS ones are checked
+    # under both the aws-connection Variable Group names and their legacy equivalents.
+    required_env_vars = [
+        ("AWS_ACCESS_KEY_ID", "aws_access_key_id"),
+        ("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
+        ("AWS_REGION", "aws_region_name"),
+        ("output", "output"),
+    ]
+    for var, legacy_var in required_env_vars:
+        if not (os.getenv(var) or os.getenv(legacy_var)):
             raise ValueError(f"Environment variable {var} is required but not set.")
 
     try:

--- a/python/sources/snowplow_source/main.py
+++ b/python/sources/snowplow_source/main.py
@@ -21,18 +21,6 @@ producer_topic = None
 quix_producer = None
 
 
-def conn_var(new_name: str, legacy_name: str, default: str = None) -> str:
-    """
-    Read a connection env var by the name the shared aws-connection Variable Group
-    injects, falling back to the legacy name so deployments created before the rename
-    keep working.
-    """
-    value = os.getenv(new_name) or os.getenv(legacy_name) or default
-    if value is None:
-        raise KeyError(f"{new_name} (or legacy {legacy_name})")
-    return value
-
-
 def connect_to_aws() -> bool:
     global kinesis_client
 
@@ -43,9 +31,9 @@ def connect_to_aws() -> bool:
     try:
         kinesis_client = boto3.client(
             'kinesis',
-            aws_access_key_id = conn_var("AWS_ACCESS_KEY_ID", "aws_access_key_id"),
-            aws_secret_access_key = conn_var("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
-            region_name = conn_var("AWS_REGION", "aws_region_name")
+            aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"],
+            region_name = os.environ["AWS_REGION"]
         )
     except Exception as e:
         print(f"ERROR! - Failed to connect to AWS: {e}")
@@ -129,16 +117,10 @@ def connect_to_quix():
 def main():
     global run
 
-    # validate the required env vars have been set supplied. The AWS ones are checked
-    # under both the aws-connection Variable Group names and their legacy equivalents.
-    required_env_vars = [
-        ("AWS_ACCESS_KEY_ID", "aws_access_key_id"),
-        ("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
-        ("AWS_REGION", "aws_region_name"),
-        ("output", "output"),
-    ]
-    for var, legacy_var in required_env_vars:
-        if not (os.getenv(var) or os.getenv(legacy_var)):
+    # validate the required env vars have been set supplied
+    required_env_vars = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION", "output"]
+    for var in required_env_vars:
+        if var not in os.environ:
             raise ValueError(f"Environment variable {var} is required but not set.")
 
     try:

--- a/python/sources/sql_cdc/README.md
+++ b/python/sources/sql_cdc/README.md
@@ -37,6 +37,14 @@ Note that the columns to rename and columns to drop settings do not affect the s
 
 Driver and columns to rename should include `{` and `}` and the start and end of their values and these MUST be escaped with a `\`.
 
+These come from the shared **`sqlserver-connection`** Variable Group (SQL Server Connection), so the connection is defined once per environment rather than per deployment:
+
+- `SQL_SERVER`
+- `SQL_DATABASE`
+- `SQL_USERNAME`
+- `SQL_PASSWORD`
+- `SQL_DRIVER`
+
 ## Contribute
 
 Submit forked projects to the Quix [GitHub](https://github.com/quixio/quix-samples) repo. Any new project that we accept will be attributed to you and you'll receive $200 in Quix credit.

--- a/python/sources/sql_cdc/library.json
+++ b/python/sources/sql_cdc/library.json
@@ -28,36 +28,50 @@
       "Required": true
     },
     {
-      "Name": "SQL_SERVER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "SQL Server hostname or IP address",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "SQL_DATABASE",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "Database name",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "SQL_USERNAME",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "SQL Server username",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "SQL_PASSWORD",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "SQL Server password",
-      "DefaultValue": "",
-      "Required": true
+      "Name": "SQLSERVER_CONNECTION",
+      "InputType": "VariableGroup",
+      "Description": "SQL Server host, database and credentials from a shared Variable Group.",
+      "VariableGroupId": "sqlserver-connection",
+      "VariableGroupName": "SQL Server Connection",
+      "VariableGroupDescription": "Shared SQL Server host, database, credentials and ODBC driver.",
+      "Required": true,
+      "Variables": [
+        {
+          "Key": "SQL_SERVER",
+          "Description": "Host address of your SQL Server instance",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "SQL_DATABASE",
+          "Description": "Database to read from",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "SQL_USERNAME",
+          "Description": "Username to connect with",
+          "DefaultValue": "",
+          "Secret": false,
+          "Required": true
+        },
+        {
+          "Key": "SQL_PASSWORD",
+          "Description": "Password for that user",
+          "DefaultValue": "",
+          "Secret": true,
+          "Required": true
+        },
+        {
+          "Key": "SQL_DRIVER",
+          "Description": "ODBC driver name, as installed in the container",
+          "DefaultValue": "{ODBC Driver 18 for SQL Server}",
+          "Secret": false,
+          "Required": false
+        }
+      ]
     },
     {
       "Name": "SQL_SCHEMA",
@@ -74,14 +88,6 @@
       "Description": "Table name to capture changes from. CDC must be enabled on this table.",
       "DefaultValue": "",
       "Required": true
-    },
-    {
-      "Name": "SQL_DRIVER",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "ODBC driver name",
-      "DefaultValue": "{ODBC Driver 18 for SQL Server}",
-      "Required": false
     },
     {
       "Name": "POLL_INTERVAL_SECONDS",

--- a/python/transformations/fmu-runner/app.yaml
+++ b/python/transformations/fmu-runner/app.yaml
@@ -9,22 +9,6 @@ variables:
     inputType: OutputTopic
     description: Name of the output topic to write simulation results to.
     defaultValue: simulation-results
-  - name: S3_ENDPOINT
-    inputType: FreeText
-    description: S3/MinIO endpoint URL for fetching FMU model binaries.
-    defaultValue: http://minio:80
-  - name: S3_ACCESS_KEY
-    inputType: Secret
-    description: S3 access key ID.
-    secretKey: s3_user
-  - name: S3_SECRET_KEY
-    inputType: Secret
-    description: S3 secret access key.
-    secretKey: s3_password
-  - name: S3_BUCKET
-    inputType: FreeText
-    description: S3 bucket name for FMU models.
-    defaultValue: fmu-models
 dockerfile: dockerfile
 runEntryPoint: main.py
 defaultFile: main.py

--- a/python/transformations/fmu-runner/library.json
+++ b/python/transformations/fmu-runner/library.json
@@ -38,38 +38,6 @@
       "Description": "Name of the output topic to write simulation results to.",
       "DefaultValue": "simulation-results",
       "Required": true
-    },
-    {
-      "Name": "S3_ENDPOINT",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "S3/MinIO endpoint URL for fetching FMU model binaries.",
-      "DefaultValue": "http://minio:80",
-      "Required": true
-    },
-    {
-      "Name": "S3_ACCESS_KEY",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "S3 access key ID.",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "S3_SECRET_KEY",
-      "Type": "EnvironmentVariable",
-      "InputType": "Secret",
-      "Description": "S3 secret access key.",
-      "DefaultValue": "",
-      "Required": true
-    },
-    {
-      "Name": "S3_BUCKET",
-      "Type": "EnvironmentVariable",
-      "InputType": "FreeText",
-      "Description": "S3 bucket name where FMU models are stored.",
-      "DefaultValue": "fmu-models",
-      "Required": true
     }
   ],
   "DeploySettings": {

--- a/tests/destinations/influxdb_1/docker-compose.test.yml
+++ b/tests/destinations/influxdb_1/docker-compose.test.yml
@@ -40,11 +40,11 @@ services:
     environment:
       - Quix__Broker__Address=kafka:9092
       - input=test-influxdb1-input
-      - INFLUXDB_HOST=influxdb
-      - INFLUXDB_PORT=8086
-      - INFLUXDB_USERNAME=testuser
-      - INFLUXDB_PASSWORD=testpass
-      - INFLUXDB_DATABASE=testdb
+      - INFLUXDB1_HOST=influxdb
+      - INFLUXDB1_PORT=8086
+      - INFLUXDB1_USERNAME=testuser
+      - INFLUXDB1_PASSWORD=testpass
+      - INFLUXDB1_DATABASE=testdb
       - INFLUXDB_MEASUREMENT_NAME=test_measurement
       - INFLUXDB_FIELD_KEYS=temperature,humidity
       - INFLUXDB_TAG_KEYS=sensor_id

--- a/tests/destinations/mongodb/docker-compose.test.yml
+++ b/tests/destinations/mongodb/docker-compose.test.yml
@@ -38,12 +38,12 @@ services:
       - Quix__Broker__Address=kafka:9092
       - input=test-mongodb-input
       - CONSUMER_GROUP_NAME=mongodb-test-consumer
-      - MONGODB_HOST=mongodb
-      - MONGODB_PORT=27017
-      - MONGODB_USERNAME=admin
-      - MONGODB_PASSWORD=password
-      - MONGODB_DB=testdb
-      - MONGODB_COLLECTION=testcollection
+      - MONGO_HOST=mongodb
+      - MONGO_PORT=27017
+      - MONGO_USER=admin
+      - MONGO_PASSWORD=password
+      - MONGO_DATABASE=testdb
+      - MONGO_COLLECTION=testcollection
       - BUFFER_SIZE=1
       - BUFFER_DELAY=0.1
     networks:

--- a/tests/destinations/postgres/docker-compose.test.yml
+++ b/tests/destinations/postgres/docker-compose.test.yml
@@ -41,7 +41,7 @@ services:
       - input=test-postgres-input
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
-      - POSTGRES_DBNAME=testdb
+      - POSTGRES_DB=testdb
       - POSTGRES_USER=testuser
       - POSTGRES_PASSWORD=testpass
       - POSTGRES_TABLE=test_data

--- a/tests/destinations/s3-file/docker-compose.test.yml
+++ b/tests/destinations/s3-file/docker-compose.test.yml
@@ -62,7 +62,7 @@ services:
       - S3_BUCKET_DIRECTORY=test_data
       - AWS_ACCESS_KEY_ID=minioadmin
       - AWS_SECRET_ACCESS_KEY=minioadmin
-      - AWS_REGION_NAME=us-east-1
+      - AWS_REGION=us-east-1
       - AWS_ENDPOINT_URL_S3=http://minio:9000
       - FILE_FORMAT=json
     networks:

--- a/tests/docker/grafana/docker-compose.test.yml
+++ b/tests/docker/grafana/docker-compose.test.yml
@@ -1,15 +1,58 @@
-# Build-only test for docker/grafana.
-# Verifies the image builds and the init script + provisioning are in place.
+# timeout: 240
+# Runtime test for docker/grafana.
+#
+# Boots Grafana with ONLY the influxdb2-config Variable Group key name set
+# (INFLUXDB2_TOKEN) and no INFLUXDB_TOKEN anywhere, then asks Grafana's API whether the
+# provisioned InfluxDB datasource has its token set. Grafana reports secure fields via
+# `secureJsonFields`, so token=true proves ${INFLUXDB2_TOKEN} in
+# provisioning/datasources/influxdb.yaml was substituted with a non-empty value - which
+# only happens if init.sh exported it.
 
 services:
   grafana:
     build:
       context: ../../../docker/grafana
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        test -d /provisioning &&
-        echo 'Success: build + layout check passed'
-      "
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=grouppass
+      - INFLUXDB2_TOKEN=grouptokenabc123
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: curlimages/curl:8.11.1
+    depends_on:
+      grafana:
+        condition: service_started
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for Grafana to provision the InfluxDB datasource..."
+        for i in $$(seq 1 60); do
+          body=$$(curl -sS -u admin:grouppass \
+                    http://grafana:3000/api/datasources/name/influxdb 2>/dev/null)
+          case "$$body" in
+            *'"secureJsonFields"'*)
+              echo "$$body" | grep -q '"token":[[:space:]]*true' && {
+                echo "Success: the datasource token was provisioned from INFLUXDB2_TOKEN"
+                exit 0
+              }
+              echo "FAILED: datasource exists but its token is unset -"
+              echo "        \$${INFLUXDB2_TOKEN} substituted to empty, so the mapping did not apply"
+              exit 1
+              ;;
+          esac
+          sleep 3
+        done
+        echo "FAILED: the influxdb datasource never appeared in Grafana"
+        curl -sS -u admin:grouppass http://grafana:3000/api/datasources/name/influxdb
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/docker/grafana/docker-compose.test.yml
+++ b/tests/docker/grafana/docker-compose.test.yml
@@ -2,11 +2,10 @@
 # Runtime test for docker/grafana.
 #
 # Boots Grafana with ONLY the influxdb2-config Variable Group key name set
-# (INFLUXDB2_TOKEN) and no INFLUXDB_TOKEN anywhere, then asks Grafana's API whether the
-# provisioned InfluxDB datasource has its token set. Grafana reports secure fields via
-# `secureJsonFields`, so token=true proves ${INFLUXDB2_TOKEN} in
-# provisioning/datasources/influxdb.yaml was substituted with a non-empty value - which
-# only happens if init.sh exported it.
+# (INFLUXDB2_TOKEN), then asks Grafana's API whether the provisioned InfluxDB datasource
+# has its token set. Grafana reports secure fields via `secureJsonFields`, so token=true
+# proves ${INFLUXDB2_TOKEN} in provisioning/datasources/influxdb.yaml was substituted with
+# a non-empty value - i.e. the group key reached Grafana through to provisioning.
 
 services:
   grafana:

--- a/tests/docker/influxdb1/docker-compose.test.yml
+++ b/tests/docker/influxdb1/docker-compose.test.yml
@@ -1,16 +1,62 @@
-# Build-only test for docker/influxdb1.
-# Verifies the image builds, the init script is in place, and the
-# embedded influx.conf was copied to /etc/influxdb/.
+# timeout: 300
+# Runtime test for docker/influxdb1.
+#
+# Boots the server with ONLY the influxdb1-config Variable Group key names set
+# (INFLUXDB1_USERNAME / INFLUXDB1_PASSWORD / INFLUXDB1_DATABASE) and no INFLUXDB_ADMIN_*
+# or INFLUXDB_DB anywhere, then queries over HTTP with those credentials. init.sh enables
+# INFLUXDB_HTTP_AUTH_ENABLED, so an authenticated query succeeding *and* an
+# unauthenticated one being refused proves the group keys were mapped through.
 
 services:
-  influxdb1:
+  influxdb:
     build:
       context: ../../../docker/influxdb1
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        test -f /etc/influxdb/influx.conf &&
-        echo 'Success: build + layout check passed'
-      "
+    environment:
+      - INFLUXDB1_USERNAME=groupuser
+      - INFLUXDB1_PASSWORD=grouppass
+      - INFLUXDB1_DATABASE=groupdb
+    # influxdb:1.12 runs as a non-root user, so it cannot create /app itself. Quix Cloud
+    # mounts state there; a world-writable tmpfs reproduces that locally.
+    tmpfs:
+      - /app:mode=1777
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: curlimages/curl:8.11.1
+    depends_on:
+      influxdb:
+        condition: service_started
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for InfluxDB v1 to accept the group credentials..."
+        for i in $$(seq 1 60); do
+          if curl -sS -f -G 'http://influxdb:8086/query' \
+               -u groupuser:grouppass \
+               --data-urlencode 'q=SHOW DATABASES' | grep -q groupdb; then
+            echo "Authenticated query succeeded and groupdb exists."
+            code=$$(curl -s -o /dev/null -w '%{http_code}' -G 'http://influxdb:8086/query' \
+                      --data-urlencode 'q=SHOW DATABASES')
+            if [ "$$code" = "200" ]; then
+              echo "FAILED: unauthenticated query returned 200 - HTTP auth is not enforced"
+              exit 1
+            fi
+            echo "Success: init.sh mapped INFLUXDB1_* onto INFLUXDB_ADMIN_USER/PASSWORD/DB"
+            exit 0
+          fi
+          sleep 3
+        done
+        echo "FAILED: could not query as the INFLUXDB1_USERNAME/PASSWORD from the group"
+        curl -sS -G 'http://influxdb:8086/query' -u groupuser:grouppass --data-urlencode 'q=SHOW DATABASES'
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/docker/influxdb2/docker-compose.test.yml
+++ b/tests/docker/influxdb2/docker-compose.test.yml
@@ -1,16 +1,53 @@
-# Build-only test for docker/influxdb2.
-# Verifies the image builds, the init script is in place, and the
-# influx-configs.toml was copied to /etc/influxdb2/.
+# timeout: 300
+# Runtime test for docker/influxdb2.
+#
+# Boots the server with ONLY the influxdb2-config Variable Group key names set
+# (INFLUXDB2_TOKEN / PASSWORD / BUCKET / USERNAME / ORG) and no DOCKER_INFLUXDB_INIT_*
+# override anywhere, then lists buckets with that token and org. Since `influx setup` in
+# init.sh is what creates them, a successful listing proves the group keys were mapped onto
+# the DOCKER_INFLUXDB_INIT_* names the setup call reads.
 
 services:
-  influxdb2:
+  influxdb:
     build:
       context: ../../../docker/influxdb2
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        test -f /etc/influxdb2/influx-configs.toml &&
-        echo 'Success: build + layout check passed'
-      "
+    environment:
+      - INFLUXDB2_TOKEN=grouptokenabc123
+      - INFLUXDB2_PASSWORD=grouppassword
+      - INFLUXDB2_BUCKET=groupbucket
+      - INFLUXDB2_USERNAME=groupuser
+      - INFLUXDB2_ORG=grouporg
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: influxdb:2.7.12
+    depends_on:
+      influxdb:
+        condition: service_started
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for InfluxDB v2 to be set up from the group values..."
+        for i in $$(seq 1 60); do
+          if influx bucket list --host http://influxdb:8086 \
+               --token grouptokenabc123 --org grouporg 2>/dev/null | grep -q groupbucket; then
+            echo "Success: init.sh mapped INFLUXDB2_* onto DOCKER_INFLUXDB_INIT_*"
+            echo "         (token, org and bucket from the group all took effect)"
+            exit 0
+          fi
+          sleep 3
+        done
+        echo "FAILED: the group token/org/bucket did not reach influx setup"
+        influx bucket list --host http://influxdb:8086 --token grouptokenabc123 --org grouporg
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/docker/minio/docker-compose.test.yml
+++ b/tests/docker/minio/docker-compose.test.yml
@@ -1,14 +1,48 @@
-# Build-only test for docker/minio.
-# Verifies the image builds and the init script is in place.
+# timeout: 240
+# Runtime test for docker/minio.
+#
+# Boots MinIO with ONLY the aws-connection Variable Group key names set
+# (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) and no MINIO_ROOT_* anywhere, then
+# authenticates with those credentials. MinIO's root user *is* the S3 access key, so this
+# proves init.sh maps the group keys onto MINIO_ROOT_USER / MINIO_ROOT_PASSWORD.
 
 services:
   minio:
     build:
       context: ../../../docker/minio
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        echo 'Success: build + layout check passed'
-      "
+    environment:
+      - AWS_ACCESS_KEY_ID=groupkeyid
+      - AWS_SECRET_ACCESS_KEY=groupsecret123
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_started
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for MinIO to accept the group credentials..."
+        for i in $$(seq 1 40); do
+          if mc alias set t http://minio:9000 groupkeyid groupsecret123 >/dev/null 2>&1; then
+            mc ls t >/dev/null 2>&1 || true
+            echo "Success: init.sh mapped AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY onto MINIO_ROOT_*"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "FAILED: could not authenticate with the AWS_* credentials from the group"
+        mc alias set t http://minio:9000 groupkeyid groupsecret123
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/docker/mongodb/docker-compose.test.yml
+++ b/tests/docker/mongodb/docker-compose.test.yml
@@ -1,14 +1,49 @@
-# Build-only test for docker/mongodb.
-# Verifies the image builds and the init script is in place.
+# timeout: 240
+# Runtime test for docker/mongodb.
+#
+# Boots the image with ONLY the mongodb-connection Variable Group key names set
+# (MONGO_USER / MONGO_PASSWORD) and no MONGO_INITDB_ROOT_* anywhere, then authenticates
+# with those credentials. This proves init.sh maps the group keys onto the names the mongo
+# image initialises its root user from - the mapping is otherwise untested, since the
+# entrypoint never runs under a build-only test.
 
 services:
   mongodb:
     build:
       context: ../../../docker/mongodb
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        echo 'Success: build + layout check passed'
-      "
+    environment:
+      - MONGO_USER=groupuser
+      - MONGO_PASSWORD=grouppass
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: mongo:8.0.21
+    depends_on:
+      mongodb:
+        condition: service_started
+    entrypoint:
+      - sh
+      - -c
+      - |
+        URI="mongodb://groupuser:grouppass@mongodb:27017/?authSource=admin"
+        echo "Waiting for MongoDB to accept the group credentials..."
+        for i in $$(seq 1 60); do
+          if mongosh "$$URI" --quiet --eval 'db.adminCommand({ping:1})' >/dev/null 2>&1; then
+            echo "Success: init.sh mapped MONGO_USER/MONGO_PASSWORD onto MONGO_INITDB_ROOT_*"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "FAILED: could not authenticate as the MONGO_USER/MONGO_PASSWORD from the group"
+        mongosh "$$URI" --quiet --eval 'db.adminCommand({ping:1})'
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/docker/mqtt/docker-compose.test.yml
+++ b/tests/docker/mqtt/docker-compose.test.yml
@@ -1,9 +1,8 @@
 # timeout: 240
 # Runtime test for docker/mqtt.
 #
-# Boots the broker with ONLY the mqtt-connection Variable Group key names set
-# (mqtt_username / mqtt_password) and no MQTT_USERNAME / MQTT_PASSWORD anywhere, then
-# publishes using those credentials. mosquitto.conf sets allow_anonymous false, so a
+# Boots the broker with only the mqtt-connection Variable Group keys set
+# (mqtt_username / mqtt_password), then publishes using those credentials. mosquitto.conf sets allow_anonymous false, so a
 # successful publish proves init.sh built the password file from the group keys.
 
 services:

--- a/tests/docker/mqtt/docker-compose.test.yml
+++ b/tests/docker/mqtt/docker-compose.test.yml
@@ -1,16 +1,55 @@
-# Build-only test for docker/mqtt.
-# Verifies the image builds and both the init script and the bundled
-# mosquitto.conf landed in the expected locations.
+# timeout: 240
+# Runtime test for docker/mqtt.
+#
+# Boots the broker with ONLY the mqtt-connection Variable Group key names set
+# (mqtt_username / mqtt_password) and no MQTT_USERNAME / MQTT_PASSWORD anywhere, then
+# publishes using those credentials. mosquitto.conf sets allow_anonymous false, so a
+# successful publish proves init.sh built the password file from the group keys.
 
 services:
   mqtt:
     build:
       context: ../../../docker/mqtt
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        test -f /mosquitto/config/mosquitto.conf &&
-        echo 'Success: build + layout check passed'
-      "
+    environment:
+      - mqtt_username=groupuser
+      - mqtt_password=grouppass
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: eclipse-mosquitto:2.0.22
+    depends_on:
+      mqtt:
+        condition: service_started
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for the broker to accept the group credentials..."
+        for i in $$(seq 1 40); do
+          if mosquitto_pub -h mqtt -p 1883 -u groupuser -P grouppass \
+               -t test/mapping -m ok >/dev/null 2>&1; then
+            echo "Authenticated publish succeeded."
+            # An anonymous publish must still be refused, otherwise the password file
+            # was never applied and the success above proves nothing.
+            if mosquitto_pub -h mqtt -p 1883 -t test/mapping -m nope >/dev/null 2>&1; then
+              echo "FAILED: anonymous publish was accepted - auth is not being enforced"
+              exit 1
+            fi
+            echo "Success: init.sh built the password file from mqtt_username/mqtt_password"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "FAILED: could not publish as the mqtt_username/mqtt_password from the group"
+        mosquitto_pub -h mqtt -p 1883 -u groupuser -P grouppass -t test/mapping -m ok
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/docker/postgres/docker-compose.test.yml
+++ b/tests/docker/postgres/docker-compose.test.yml
@@ -1,16 +1,51 @@
-# Build-only test for docker/postgres.
-# Verifies the image builds, the wal2json plugin was installed via apt,
-# and the init script is in place.
+# timeout: 240
+# Runtime test for docker/postgres.
+#
+# Boots the server with the postgres-connection Variable Group key names and connects with
+# them. The postgres image reads POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB under
+# exactly those names, so there is no init.sh mapping here - what this asserts is that the
+# group keys are the names the image actually wants, and that they override the defaults
+# baked into the dockerfile (POSTGRES_USER=admin, POSTGRES_DB=quix).
 
 services:
-  postgres:
+  postgresql:
     build:
       context: ../../../docker/postgres
       dockerfile: dockerfile
-    entrypoint: >
-      sh -c "
-        test -x /init.sh &&
-        dpkg -s postgresql-16-wal2json > /dev/null &&
-        echo 'Success: build + apt install + layout check passed'
-      "
+    environment:
+      - POSTGRES_USER=groupuser
+      - POSTGRES_PASSWORD=grouppass
+      - POSTGRES_DB=groupdb
+    networks:
+      - test-network
     stop_grace_period: 3s
+
+  test-runner:
+    image: postgres:16
+    depends_on:
+      postgresql:
+        condition: service_started
+    environment:
+      - PGPASSWORD=grouppass
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for PostgreSQL to accept the group credentials..."
+        for i in $$(seq 1 60); do
+          if psql -h postgresql -U groupuser -d groupdb -c 'select 1' >/dev/null 2>&1; then
+            echo "Success: the group keys initialised the server (user=groupuser db=groupdb)"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "FAILED: could not connect as groupuser/groupdb - the dockerfile defaults may have won"
+        psql -h postgresql -U groupuser -d groupdb -c 'select 1'
+        exit 1
+    networks:
+      - test-network
+    stop_grace_period: 3s
+
+networks:
+  test-network:
+    driver: bridge

--- a/tests/sources/influxdb_2/docker-compose.test.yml
+++ b/tests/sources/influxdb_2/docker-compose.test.yml
@@ -41,10 +41,10 @@ services:
     environment:
       - Quix__Broker__Address=kafka:9092
       - output=test-influxdb2-output
-      - INFLUXDB_HOST=http://influxdb:8086
-      - INFLUXDB_TOKEN=testtokenabc123
-      - INFLUXDB_ORG=testorg
-      - INFLUXDB_BUCKET=testbucket
+      - INFLUXDB2_HOST=http://influxdb:8086
+      - INFLUXDB2_TOKEN=testtokenabc123
+      - INFLUXDB2_ORG=testorg
+      - INFLUXDB2_BUCKET=testbucket
       - task_interval=15s
     networks:
       - test-network
@@ -61,10 +61,10 @@ services:
     environment:
       - Quix__Broker__Address=kafka:9092
       - TEST_OUTPUT_TOPIC=test-influxdb2-output
-      - INFLUXDB_HOST=http://influxdb:8086
-      - INFLUXDB_TOKEN=testtokenabc123
-      - INFLUXDB_ORG=testorg
-      - INFLUXDB_BUCKET=testbucket
+      - INFLUXDB2_HOST=http://influxdb:8086
+      - INFLUXDB2_TOKEN=testtokenabc123
+      - INFLUXDB2_ORG=testorg
+      - INFLUXDB2_BUCKET=testbucket
     command: >
       sh -c "
         echo 'Installing InfluxDB client...' &&

--- a/tests/sources/influxdb_2/populate_influxdb.py
+++ b/tests/sources/influxdb_2/populate_influxdb.py
@@ -5,10 +5,10 @@ from influxdb_client.client.write_api import SYNCHRONOUS
 
 def main():
     # InfluxDB connection details
-    url = os.getenv("INFLUXDB_HOST", "http://influxdb:8086")
-    token = os.getenv("INFLUXDB_TOKEN", "testtokenabc123")
-    org = os.getenv("INFLUXDB_ORG", "testorg")
-    bucket = os.getenv("INFLUXDB_BUCKET", "testbucket")
+    url = os.getenv("INFLUXDB2_HOST", "http://influxdb:8086")
+    token = os.getenv("INFLUXDB2_TOKEN", "testtokenabc123")
+    org = os.getenv("INFLUXDB2_ORG", "testorg")
+    bucket = os.getenv("INFLUXDB2_BUCKET", "testbucket")
 
     print(f"Connecting to InfluxDB at {url}")
 

--- a/tests/sources/postgres_cdc/docker-compose.test.yml
+++ b/tests/sources/postgres_cdc/docker-compose.test.yml
@@ -57,13 +57,13 @@ services:
         tail -f /dev/null
       "
     environment:
-      - PG_HOST=postgres
-      - PG_PORT=5432
-      - PG_USER=testuser
-      - PG_PASSWORD=testpass
-      - PG_DATABASE=testdb
-      - PG_SCHEMA=public
-      - PG_TABLE=test_table
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=testuser
+      - POSTGRES_PASSWORD=testpass
+      - POSTGRES_DB=testdb
+      - POSTGRES_SCHEMA=public
+      - POSTGRES_TABLE=test_table
     volumes:
       - ./setup_postgres.py:/tests/setup_postgres.py:ro
     networks:
@@ -84,13 +84,13 @@ services:
     environment:
       - Quix__Broker__Address=kafka:9092
       - output=test-postgres-cdc-output
-      - PG_HOST=postgres
-      - PG_PORT=5432
-      - PG_USER=testuser
-      - PG_PASSWORD=testpass
-      - PG_DATABASE=testdb
-      - PG_SCHEMA=public
-      - PG_TABLE=test_table
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=testuser
+      - POSTGRES_PASSWORD=testpass
+      - POSTGRES_DB=testdb
+      - POSTGRES_SCHEMA=public
+      - POSTGRES_TABLE=test_table
     networks:
       - test-network
     depends_on:
@@ -106,13 +106,13 @@ services:
     environment:
       - Quix__Broker__Address=kafka:9092
       - TEST_OUTPUT_TOPIC=test-postgres-cdc-output
-      - PG_HOST=postgres
-      - PG_PORT=5432
-      - PG_USER=testuser
-      - PG_PASSWORD=testpass
-      - PG_DATABASE=testdb
-      - PG_SCHEMA=public
-      - PG_TABLE=test_table
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=testuser
+      - POSTGRES_PASSWORD=testpass
+      - POSTGRES_DB=testdb
+      - POSTGRES_SCHEMA=public
+      - POSTGRES_TABLE=test_table
       - TEST_MESSAGE_COUNT=3
     command: >
       sh -c "

--- a/tests/sources/postgres_cdc/modify_data.py
+++ b/tests/sources/postgres_cdc/modify_data.py
@@ -11,17 +11,17 @@ import time
 def main():
     # Connect to Postgres
     conn = psycopg2.connect(
-        host=os.environ["PG_HOST"],
-        port=os.environ["PG_PORT"],
-        user=os.environ["PG_USER"],
-        password=os.environ["PG_PASSWORD"],
-        database=os.environ["PG_DATABASE"]
+        host=os.environ["POSTGRES_HOST"],
+        port=os.environ["POSTGRES_PORT"],
+        user=os.environ["POSTGRES_USER"],
+        password=os.environ["POSTGRES_PASSWORD"],
+        database=os.environ["POSTGRES_DB"]
     )
     conn.autocommit = True
     cursor = conn.cursor()
 
-    schema = os.environ["PG_SCHEMA"]
-    table = os.environ["PG_TABLE"]
+    schema = os.environ["POSTGRES_SCHEMA"]
+    table = os.environ["POSTGRES_TABLE"]
     table_name = f"{schema}.{table}"
 
     try:

--- a/tests/sources/postgres_cdc/setup_postgres.py
+++ b/tests/sources/postgres_cdc/setup_postgres.py
@@ -9,17 +9,17 @@ import sys
 def main():
     # Connect to Postgres
     conn = psycopg2.connect(
-        host=os.environ["PG_HOST"],
-        port=os.environ["PG_PORT"],
-        user=os.environ["PG_USER"],
-        password=os.environ["PG_PASSWORD"],
-        database=os.environ["PG_DATABASE"]
+        host=os.environ["POSTGRES_HOST"],
+        port=os.environ["POSTGRES_PORT"],
+        user=os.environ["POSTGRES_USER"],
+        password=os.environ["POSTGRES_PASSWORD"],
+        database=os.environ["POSTGRES_DB"]
     )
     conn.autocommit = True
     cursor = conn.cursor()
 
-    schema = os.environ["PG_SCHEMA"]
-    table = os.environ["PG_TABLE"]
+    schema = os.environ["POSTGRES_SCHEMA"]
+    table = os.environ["POSTGRES_TABLE"]
 
     try:
         # Create schema if it doesn't exist

--- a/tests/sources/s3_source/docker-compose.test.yml
+++ b/tests/sources/s3_source/docker-compose.test.yml
@@ -63,9 +63,9 @@ services:
       - Quix__Deployment__Id=test-s3-source
       - output=test-s3-output
       - S3_BUCKET=test-bucket
-      - S3_REGION=us-east-1
-      - S3_SECRET=minioadmin
-      - S3_ACCESS_KEY_ID=minioadmin
+      - AWS_REGION=us-east-1
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - AWS_ACCESS_KEY_ID=minioadmin
       - S3_FOLDER_PREFIX=data/
       - POLL_INTERVAL_SECONDS=2
       - DOWNLOAD_CONTENT=True

--- a/tests/templates/destination/docker-compose.test.yml
+++ b/tests/templates/destination/docker-compose.test.yml
@@ -85,10 +85,10 @@ services:
       # - DB_PASSWORD=testpass
 
       # EXAMPLE for InfluxDB:
-      # - INFLUXDB_HOST=http://[destination-service]:8086
-      # - INFLUXDB_TOKEN=testtokenabc123
-      # - INFLUXDB_ORG=testorg
-      # - INFLUXDB_DATABASE=testdb
+      # - INFLUXDB3_HOST=http://[destination-service]:8086
+      # - INFLUXDB3_TOKEN=testtokenabc123
+      # - INFLUXDB3_ORG=testorg
+      # - INFLUXDB3_DATABASE=testdb
 
       # TODO: Add destination-specific configuration
       # EXAMPLE: Table/collection/measurement naming


### PR DESCRIPTION
Moves each library item's connection details out of per-deployment variables and into shared **Variable Groups**, so a server and its clients cannot drift apart. 43 items now reference one of 26 groups, up from 5 items / 3 groups.

## Groups

**Shared by two or more items** — where a server and its clients must agree on one connection:
`mqtt-connection`, `postgres-connection`, `mongodb-connection`, `influxdb1-config`, `influxdb2-config`, `influxdb3-config`, `aws-connection`, `redis-connection`, `hivemq-connection`, `confluent-kafka-connection`

**Single-service** — for per-environment value sets:
`tdengine`, `elasticsearch`, `bigquery`, `sqlserver`, `source-kafka`, `quix-environment`, `websocket`, `http-api-auth`, `segment-webhook-auth`, `slack-webhook`, `tailscale-auth`, `anthropic-api`, `jupyter-auth`, `opcua-connection`, `mongodb-metadata-connection`

Server images that read their own fixed env var names (mongo, mosquitto, influxdb 1 and 2, minio) map the group keys in `init.sh`.

The backup manager gets its own `mongodb-metadata-connection` rather than sharing `mongodb-connection`: `METADATA_MONGO_*` is the manager's own metadata store, not the pipeline's data MongoDB. Its keys keep the prebuilt image's existing names, so no service-image change is needed.

## No legacy-name fallbacks

The first commit renamed variables behind a `conn_var(new, legacy)` fallback, following #703. The two follow-up commits remove all of them, because they could never have applied: a library item is copied into the user's own repo at the moment they deploy it, and nothing ever offers them an update. There is no population of running deployments that a rename in *this* repo can reach — an existing deployment runs its own frozen copy of the old code, with the old names in its own `quix.yaml`.

That made every `conn_var(new, legacy)` helper and every `"${NEW:-$OLD}"` shell fallback dead code, and made the comments and README lines around them assert a compatibility concern that does not exist. `conn_var` no longer appears anywhere in the repo.

#703's compatibility concern was real, but it was about the Dynamic Configuration **managed app**, which Quix does update in place — hence the side-by-side V2 there. `managed/dynamic-configuration` keeps its compatibility note for that reason.

Kept deliberately: plain `getenv` defaults (useful for local dotenv development), the `or None` coercions (an unset optional group key is injected as an empty string, not left absent), and `s3_source`'s optional credentials, so `S3FileWatcher` can still fall back to an IAM role or anonymous access.

With compatibility off the table, two further alignments were free: `postgres_cdc`'s `PG_SCHEMA` / `PG_TABLE` become `POSTGRES_SCHEMA` / `POSTGRES_TABLE` to match the PostgreSQL Sink, and `influxdb2`'s `init.sh` now validates all five group keys rather than silently falling back to the dockerfile's `ENV` defaults.

## Bugs found and fixed while converting

- the influxdb3 group descriptions exceeded the portal's 100-char cap, which leaves the Create & Assign form invalid and its submit button disabled
- `snowplow_source` validated required env vars against the legacy lowercase names, so any group-injected deployment would have been rejected
- `s3_source` lost its tolerance for unset credentials, which `S3FileWatcher` relies on to fall back to an IAM role or anonymous access
- the MQTT sources ignored `mqtt_tls_enabled` entirely (one keyed TLS off whether a username was set, the other hardcoded it on), so against the bundled plaintext broker they would have attempted TLS and failed
- the Confluent sink hardcoded `sasl.mechanism` PLAIN and ignored any CA path, so it could not reach a SCRAM cluster that its own source could
- `basic-react-template` imported a TypeScript interface as a value from a `.js` file; interfaces are erased at compile time, breaking the webpack build
- both MongoDB READMEs documented variables that no longer exist — the sink's Required list named `MONGODB_URL`, which the sink has never read at all (it takes host, port, username and password separately). Their "provide these arguments" snippets are now a pointer to assigning the shared group instead, which is the whole point of having one.

## Tests

Tests move to the names the samples actually read, so they exercise the documented interface rather than a fallback path: `influxdb_1`, `influxdb_2`, `postgres`, `postgres_cdc`, `s3-file`, `s3_source`, `mongodb`, plus the destination template's commented example.

The seven `tests/docker` build-only tests become runtime tests that execute the `init.sh` mappings and assert the credentials actually took effect. Those mappings were previously untested, since a build-only test overrides the entrypoint and never runs `init.sh`.

**Full suite: 67/67 passing.**

## Also included

- removes `fmu-runner`'s four declared-but-unread S3 variables
- marimo's `requirements.txt` (`quixlake-sdk` >=0.2.4 -> >=0.2.1, `quixportal` 2.0.4 -> 2.0.6) — already present in the working tree, not part of this work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
